### PR TITLE
CFM support for demo embedded in CMake

### DIFF
--- a/apps/demo_mn_embedded/CMakeLists.txt
+++ b/apps/demo_mn_embedded/CMakeLists.txt
@@ -44,6 +44,8 @@ INCLUDE(../common/cmake/options.cmake)
 SET(OBJDICT CiA302-4_MN)              # Set object dictionary to use
 FIND_OPLK_LIBRARY("mn")
 
+SET(CFG_CFM ON CACHE BOOL "Use Configuration Manager (CFM)")
+
 # Set generic sources and include directories for this demo
 SET(DEMO_SOURCES
     ${DEMO_SOURCE_DIR}/main.c
@@ -72,6 +74,10 @@ SET(EXECUTABLE_NAME "${PROJECT_NAME}${ARCH_EXE_SUFFIX}")
 
 ################################################################################
 # Setup compile definitions depending on configuration
+
+IF(CFG_CFM)
+    ADD_DEFINITIONS(-DCONFIG_INCLUDE_CFM)
+ENDIF()
 
 IF (CFG_KERNEL_STACK_DIRECTLINK)
     ADD_DEFINITIONS(-DCONFIG_KERNELSTACK_DIRECTLINK)


### PR DESCRIPTION
This fix adds the CFM configuration option for demo_mn_embedded projects using CMake for compilation.
