### PR TITLE
[TASK]: Allow to build several oplk kernel modules at once

### DIFF
--- a/doc/build-drivers.md
+++ b/doc/build-drivers.md
@@ -38,9 +38,17 @@ __CFG_KERNEL_DIR__.
 To build the kernel driver (e.g. for a MN using the Intel 82573 network interface):
 
       > cd <openPOWERLINK_dir>/drivers/linux/drv_kernelmod_edrv/build
-      > cmake -DCFG_OPLK_MN=TRUE -DCFG_POWERLINK_EDRV=82573 ..
+      > cmake -DCFG_OPLK_MN=TRUE -DCFG_POWERLINK_EDRV_82573=TRUE ..
       > make
       > make install
+
+Several kernel driver can be build at once, just append another
+CFG_POWERLINK_EDRV_<driver name> to the cmake command:
+
+      > cmake -DCFG_OPLK_MN=TRUE -DCFG_POWERLINK_EDRV_82573=TRUE -DCFG_POWERLINK_EDRV_I210=TRUE
+
+__NOTE__: Only one of them can be loaded at runtime since openPOWERLINK doesn't support
+several stack instances.
 
 ## Building a Linux Kernel PCIe Interface Driver {#sect_build_drivers_build_linux_pcie}
 

--- a/drivers/linux/drv_kernelmod_edrv/CMakeLists.txt
+++ b/drivers/linux/drv_kernelmod_edrv/CMakeLists.txt
@@ -4,6 +4,7 @@
 #
 # Copyright (c) 2013, SYSTEC electronik GmbH
 # Copyright (c) 2014, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+# Copyright (c) 2015, Romain Naour (openwide)
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -31,6 +32,113 @@
 ################################################################################
 
 PROJECT (oplkdrv_kernelmodule_edrv C)
+
+###############################################################################
+# edrvBuild
+###############################################################################
+MACRO(edrvBuild OPLK_EDRV)
+    SET(MODULE_NAME "oplk${OPLK_EDRV}${MODULE_NAME_SUFFIX}")
+    SET(MODULE_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/${MODULE_NAME})
+    SET(MODULE_FILE ${MODULE_NAME}.ko)
+    # Make sure that MODULE_EDRV_SOURCE_FILES is empty to avoid issue during create_symlink.
+    SET(MODULE_EDRV_SOURCE_FILES)
+
+    GET_PROPERTY(DRIVER_INCLUDE_DIRS DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES)
+    FOREACH(NEXT_INCLUDE_DIR ${DRIVER_INCLUDE_DIRS})
+        SET(MODULE_INCLUDES "${MODULE_INCLUDES} -I${NEXT_INCLUDE_DIR}")
+    ENDFOREACH()
+    ###############################################################################
+    # Configure depending selected ethernet driver
+    ###############################################################################
+    IF(${OPLK_EDRV} STREQUAL "8139")
+
+        SET(MODULE_EDRV_DEFS "${MODULE_DEFS} -DCONFIG_EDRV=8139")
+        SET(MODULE_OPLK8139_SOURCE_FILES ${MODULE_SOURCE_FILES} ${EDRV_SOURCE_DIR}/edrv-8139.c)
+        SET(MODULE_OPLK8139_SOURCE_FILES ${MODULE_OPLK8139_SOURCE_FILES} ${KERNEL_SOURCE_DIR}/timer/hrestimer-linuxkernel.c)
+        SET(MODULE_EDRV_SOURCE_FILES ${MODULE_OPLK8139_SOURCE_FILES})
+
+    ELSEIF(${OPLK_EDRV} STREQUAL "82573")
+
+        SET(MODULE_EDRV_DEFS "${MODULE_DEFS} -DCONFIG_EDRV=82573")
+        SET(MODULE_OPLK82573_SOURCE_FILES ${MODULE_SOURCE_FILES} ${EDRV_SOURCE_DIR}/edrv-82573.c)
+        SET(MODULE_OPLK82573_SOURCE_FILES ${MODULE_OPLK82573_SOURCE_FILES} ${KERNEL_SOURCE_DIR}/timer/hrestimer-linuxkernel.c)
+        SET(MODULE_EDRV_SOURCE_FILES ${MODULE_OPLK82573_SOURCE_FILES})
+
+    ELSEIF(${OPLK_EDRV} STREQUAL "8255x")
+
+        SET(MODULE_EDRV_DEFS "${MODULE_DEFS} -DCONFIG_EDRV=8255")
+        SET(MODULE_OPLK8255X_SOURCE_FILES ${MODULE_SOURCE_FILES} ${EDRV_SOURCE_DIR}/edrv-8255x.c)
+        SET(MODULE_OPLK8255X_SOURCE_FILES ${MODULE_OPLK8255X_SOURCE_FILES} ${KERNEL_SOURCE_DIR}/timer/hrestimer-linuxkernel.c)
+        SET(MODULE_EDRV_SOURCE_FILES ${MODULE_OPLK8255X_SOURCE_FILES})
+
+    ELSEIF(${OPLK_EDRV} STREQUAL "i210")
+
+        SET(MODULE_EDRV_DEFS "${MODULE_DEFS} -DCONFIG_EDRV=210 -DEDRV_USE_TTTX=TRUE")
+        SET(MODULE_OPLKI210_SOURCE_FILES ${MODULE_SOURCE_FILES} ${EDRV_SOURCE_DIR}/edrv-i210.c)
+        SET(MODULE_OPLKI210_SOURCE_FILES ${MODULE_OPLKI210_SOURCE_FILES} ${KERNEL_SOURCE_DIR}/timer/hrestimer-i210.c)
+        SET(MODULE_EDRV_SOURCE_FILES ${MODULE_OPLKI210_SOURCE_FILES})
+
+    ELSEIF(${OPLK_EDRV} STREQUAL "8111")
+
+        SET(MODULE_EDRV_DEFS "${MODULE_DEFS} -DCONFIG_EDRV=8111")
+        SET(MODULE_OPLK8111_SOURCE_FILES ${MODULE_SOURCE_FILES} ${EDRV_SOURCE_DIR}/edrv-8111.c)
+        SET(MODULE_OPLK8111_SOURCE_FILES ${MODULE_OPLK8111_SOURCE_FILES} ${KERNEL_SOURCE_DIR}/timer/hrestimer-linuxkernel.c)
+        SET(MODULE_EDRV_SOURCE_FILES ${MODULE_OPLK8111_SOURCE_FILES})
+
+    ELSEIF(${OPLK_EDRV} STREQUAL "emacps")
+        IF(CMAKE_SYSTEM_PROCESSOR MATCHES arm)
+            SET(MODULE_EDRV_DEFS "${MODULE_DEFS} -DCONFIG_EDRV=267200")
+            # 267200 corresponds to Z7200 arch of Zynq family. (Z is represented by 26)
+            SET(MODULE_EMACPS_SOURCE_FILES ${MODULE_SOURCE_FILES} ${EDRV_SOURCE_DIR}/edrv-emacps.c)
+            SET(MODULE_EMACPS_SOURCE_FILES ${MODULE_EMACPS_SOURCE_FILES} ${KERNEL_SOURCE_DIR}/timer/hrestimer-zynqttc.c)
+            SET(MODULE_EDRV_SOURCE_FILES ${MODULE_EMACPS_SOURCE_FILES})
+        ELSE()
+            MESSAGE(FATAL_ERROR "EmacPs supported only for ARM processor")
+        ENDIF()
+    ELSE()
+        MESSAGE(FATAL_ERROR
+                "No valid ethernet driver was specified during the edrvBuild() call")
+    ENDIF()
+
+    # Clear MODULE_OBJS content if already set by a previous edrv build.
+    SET(MODULE_OBJS)
+
+    # Link source files to do an out-of-source build
+    FOREACH(MODULE_SOURCE_FILE ${MODULE_EDRV_SOURCE_FILES})
+        GET_FILENAME_COMPONENT(MODULE_SOURCE_FILENAME ${MODULE_SOURCE_FILE} NAME)
+        GET_FILENAME_COMPONENT(MODULE_SOURCE_BASENAME ${MODULE_SOURCE_FILE} NAME_WE)
+        ADD_CUSTOM_COMMAND(OUTPUT ${MODULE_OUTPUT_DIR}/src/${MODULE_SOURCE_FILENAME}
+                        COMMAND ${CMAKE_COMMAND} -E make_directory ${MODULE_OUTPUT_DIR}/src
+                        COMMAND ${CMAKE_COMMAND} -E create_symlink ${MODULE_SOURCE_FILE} ${MODULE_OUTPUT_DIR}/src/${MODULE_SOURCE_FILENAME}
+                        )
+        SET(MODULE_OBJS "${MODULE_OBJS} src/${MODULE_SOURCE_BASENAME}.o")
+        SET(MODULE_LINKED_SOURCE_FILES ${MODULE_LINKED_SOURCE_FILES} ${MODULE_OUTPUT_DIR}/src/${MODULE_SOURCE_FILENAME})
+    ENDFOREACH()
+
+    CONFIGURE_FILE(${TOOLS_DIR}/linux/Kbuild.in ${MODULE_OUTPUT_DIR}/Kbuild)
+
+    ADD_CUSTOM_COMMAND(
+        OUTPUT ${MODULE_OUTPUT_DIR}/${MODULE_FILE}
+        COMMAND ${CMAKE_MAKE_PROGRAM} ${MAKE_KERNEL_CROSSCOMPILING_PARAMS} -C ${KERNEL_DIR} M=${MODULE_OUTPUT_DIR} modules
+        WORKING_DIRECTORY ${MODULE_OUTPUT_DIR}
+        DEPENDS ${MODULE_LINKED_SOURCE_FILES} ${TOOLS_DIR}/linux/Kbuild.in
+        VERBATIM
+    )
+
+    ADD_CUSTOM_TARGET(
+        ${MODULE_NAME}
+        ALL
+        DEPENDS ${MODULE_OUTPUT_DIR}/${MODULE_FILE}
+        )
+
+    ADD_CUSTOM_TARGET(
+        module_${MODULE_NAME}_clean
+        COMMAND ${CMAKE_MAKE_PROGRAM} -C ${KERNEL_DIR} M=${MODULE_OUTPUT_DIR} clean
+        )
+
+    INSTALL(FILES ${MODULE_OUTPUT_DIR}/${MODULE_FILE} DESTINATION ${PROJECT_NAME})
+
+ENDMACRO()
 
 # include cmake modules
 INCLUDE(CMakeDependentOption)
@@ -68,9 +176,12 @@ SET(CFG_DEBUG_LVL "0xEC000000L" CACHE STRING "Debug Level for debug output")
 SET(CFG_KERNEL_DIR "" CACHE PATH
         "Select the kernel directory to be used, if not specified, system kernel dir will be used!")
 
-SET(CFG_POWERLINK_EDRV "82573" CACHE STRING
-        "Valid drivers are 8139, 82573, 8255x, i210, 8111, emacps")
-SET_PROPERTY(CACHE CFG_POWERLINK_EDRV PROPERTY STRINGS 8139 82573 8255x i210 8111 emacps)
+OPTION (CFG_POWERLINK_EDRV_82573 "Compile 82573 OPLK driver" ON)
+OPTION (CFG_POWERLINK_EDRV_8139 "Compile 8139 OPLK driver" OFF)
+OPTION (CFG_POWERLINK_EDRV_8255X "Compile 8255x OPLK driver" OFF)
+OPTION (CFG_POWERLINK_EDRV_I210 "Compile i210 OPLK driver" OFF)
+OPTION (CFG_POWERLINK_EDRV_8111 "Compile 8111 OPLK driver" OFF)
+OPTION (CFG_POWERLINK_EDRV_EMACPS "Compile emacps OPLK driver" OFF)
 
 ################################################################################
 # Set global directories
@@ -92,76 +203,9 @@ IF(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     )
 ENDIF()
 
-################################################################################
-#
-# Configure depending selected ethernet driver
-#
-IF(CFG_POWERLINK_EDRV STREQUAL "8139")
-
-    SET(MODULE_NAME "oplk8139")
-    SET(MODULE_DEFS "${MODULE_DEFS} -DCONFIG_EDRV=8139")
-    SET(MODULE_SOURCE_FILES ${MODULE_SOURCE_FILES} ${EDRV_SOURCE_DIR}/edrv-8139.c)
-
-ELSEIF(CFG_POWERLINK_EDRV STREQUAL "82573")
-
-    SET(MODULE_NAME "oplk82573")
-    SET(MODULE_DEFS "${MODULE_DEFS} -DCONFIG_EDRV=82573")
-    SET(MODULE_SOURCE_FILES ${MODULE_SOURCE_FILES} ${EDRV_SOURCE_DIR}/edrv-82573.c)
-
-ELSEIF(CFG_POWERLINK_EDRV STREQUAL "8255x")
-
-    SET(MODULE_NAME "oplk8255x")
-    SET(MODULE_DEFS "${MODULE_DEFS} -DCONFIG_EDRV=8255")
-    SET(MODULE_SOURCE_FILES ${MODULE_SOURCE_FILES} ${EDRV_SOURCE_DIR}/edrv-8255x.c)
-
-ELSEIF(CFG_POWERLINK_EDRV STREQUAL "i210")
-
-    SET(MODULE_NAME "oplki210")
-    SET(MODULE_DEFS "${MODULE_DEFS} -DCONFIG_EDRV=210 -DEDRV_USE_TTTX=TRUE")
-    SET(MODULE_SOURCE_FILES ${MODULE_SOURCE_FILES} ${EDRV_SOURCE_DIR}/edrv-i210.c)
-
-ELSEIF(CFG_POWERLINK_EDRV STREQUAL "8111")
-
-    SET(MODULE_NAME "oplk8111")
-    SET(MODULE_DEFS "${MODULE_DEFS} -DCONFIG_EDRV=8111")
-    SET(MODULE_SOURCE_FILES ${MODULE_SOURCE_FILES} ${EDRV_SOURCE_DIR}/edrv-8111.c)
-
-ELSEIF(CFG_POWERLINK_EDRV STREQUAL "emacps")
-    IF(CMAKE_SYSTEM_PROCESSOR MATCHES arm)
-        SET(MODULE_NAME "oplkemacps")
-        SET(MODULE_DEFS "${MODULE_DEFS} -DCONFIG_EDRV=267200")
-        # 267200 corresponds to Z7200 arch of Zynq family. (Z is represented by 26)
-        SET(MODULE_SOURCE_FILES ${MODULE_SOURCE_FILES} ${EDRV_SOURCE_DIR}/edrv-emacps.c)
-    ELSE()
-        MESSAGE(FATAL_ERROR "EmacPs supported only for ARM processor")
-    ENDIF()
-ELSE()
-
-    message(FATAL_ERROR
-            "No valid ethernet driver was specified in CFG_POWERLINK_EDRV")
-
-ENDIF()
-
 ###############################################################################
-#
-# Configure depending selected mode
-#
-IF(CFG_OPLK_MN)
-    IF(CFG_INCLUDE_MN_REDUNDANCY)
-         SET(MODULE_DEFS "${MODULE_DEFS} -DCONFIG_INCLUDE_NMT_RMN")
-    ENDIF()
-    SET(MODULE_DEFS "${MODULE_DEFS} -DCONFIG_MN")
-    SET(MODULE_NAME "${MODULE_NAME}mn")
-    INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/proj/mn)
-ELSE()
-    SET(MODULE_NAME "${MODULE_NAME}cn")
-    INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/proj/cn)
-ENDIF()
-
-###############################################################################
-#
 # specifiy standard definitions
-#
+###############################################################################
 IF(CMAKE_BUILD_TYPE STREQUAL Debug OR CMAKE_BUILD_TYPE STREQUAL DEBUG)
     SET(MODULE_DEFS "${MODULE_DEFS} -D_DEBUG")
     #SET(MODULE_DEFS "${MODULE_DEFS} -D_DBG_TRACE_POINTS_")
@@ -169,24 +213,17 @@ IF(CMAKE_BUILD_TYPE STREQUAL Debug OR CMAKE_BUILD_TYPE STREQUAL DEBUG)
 ENDIF()
 
 ###############################################################################
-#
 # specifiy standard include directories
-#
-
+###############################################################################
 INCLUDE_DIRECTORIES(${OPLK_INCLUDE_DIR})
 INCLUDE_DIRECTORIES(${STACK_SOURCE_DIR})
 INCLUDE_DIRECTORIES(${COMMON_SOURCE_DIR}/circbuf)
 INCLUDE_DIRECTORIES(${KERNEL_SOURCE_DIR}/errhnd)
 INCLUDE_DIRECTORIES(${KERNEL_SOURCE_DIR}/dll)
 
-GET_PROPERTY(DRIVER_INCLUDE_DIRS DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES)
-FOREACH(NEXT_INCLUDE_DIR ${DRIVER_INCLUDE_DIRS})
-    SET(MODULE_INCLUDES "${MODULE_INCLUDES} -I${NEXT_INCLUDE_DIR}")
-ENDFOREACH()
-
-#
+###############################################################################
 # specifiy source files
-#
+###############################################################################
 SET(MODULE_SOURCE_FILES
     ${MODULE_SOURCE_FILES}
     ${CMAKE_CURRENT_SOURCE_DIR}/main.c
@@ -222,12 +259,19 @@ SET(MODULE_SOURCE_FILES
     ${ARCH_SOURCE_DIR}/target-linuxkernel.c
     )
 
-IF(CFG_POWERLINK_EDRV STREQUAL "i210")
-    SET(MODULE_SOURCE_FILES ${MODULE_SOURCE_FILES} ${KERNEL_SOURCE_DIR}/timer/hrestimer-i210.c)
-ELSEIF(CFG_POWERLINK_EDRV STREQUAL "emacps")
-    SET(MODULE_SOURCE_FILES ${MODULE_SOURCE_FILES} ${KERNEL_SOURCE_DIR}/timer/hrestimer-zynqttc.c )
+###############################################################################
+# Configure depending selected mode
+###############################################################################
+IF(CFG_OPLK_MN)
+    IF(CFG_INCLUDE_MN_REDUNDANCY)
+         SET(MODULE_DEFS "${MODULE_DEFS} -DCONFIG_INCLUDE_NMT_RMN")
+    ENDIF()
+    SET(MODULE_DEFS "${MODULE_DEFS} -DCONFIG_MN")
+    SET(MODULE_NAME_SUFFIX "mn")
+    INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/proj/mn)
 ELSE()
-    SET(MODULE_SOURCE_FILES ${MODULE_SOURCE_FILES} ${KERNEL_SOURCE_DIR}/timer/hrestimer-linuxkernel.c)
+    SET(MODULE_NAME_SUFFIX "cn")
+    INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/proj/cn)
 ENDIF()
 
 IF(CMAKE_SYSTEM_PROCESSOR MATCHES "^(i.86|x86(_64)?)$")
@@ -239,28 +283,11 @@ ELSE()
             "ami: CMAKE_SYSTEM_PROCESSOR is set to ${CMAKE_SYSTEM_PROCESSOR}. Valid targets are (x86, x86_64, arm, armv7l, i686).")
 ENDIF()
 
-SET(MODULE_FILE ${MODULE_NAME}.ko)
-SET(MODULE_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
-
 IF (CFG_KERNEL_DIR STREQUAL "")
     SET(KERNEL_DIR "/lib/modules/${CMAKE_SYSTEM_VERSION}/build")
 ELSE()
     SET(KERNEL_DIR ${CFG_KERNEL_DIR})
 ENDIF()
-
-# Link source files to do an out-of-source build
-FOREACH(MODULE_SOURCE_FILE ${MODULE_SOURCE_FILES})
-    GET_FILENAME_COMPONENT(MODULE_SOURCE_FILENAME ${MODULE_SOURCE_FILE} NAME)
-    GET_FILENAME_COMPONENT(MODULE_SOURCE_BASENAME ${MODULE_SOURCE_FILE} NAME_WE)
-    ADD_CUSTOM_COMMAND(OUTPUT ${MODULE_OUTPUT_DIR}/src/${MODULE_SOURCE_FILENAME}
-                       COMMAND ${CMAKE_COMMAND} -E make_directory ${MODULE_OUTPUT_DIR}/src
-                       COMMAND ${CMAKE_COMMAND} -E create_symlink ${MODULE_SOURCE_FILE} ${MODULE_OUTPUT_DIR}/src/${MODULE_SOURCE_FILENAME}
-                       )
-    SET(MODULE_OBJS "${MODULE_OBJS} src/${MODULE_SOURCE_BASENAME}.o")
-    SET(MODULE_LINKED_SOURCE_FILES ${MODULE_LINKED_SOURCE_FILES} ${MODULE_OUTPUT_DIR}/src/${MODULE_SOURCE_FILENAME})
-ENDFOREACH()
-
-CONFIGURE_FILE(${TOOLS_DIR}/linux/Kbuild.in ${MODULE_OUTPUT_DIR}/Kbuild)
 
 IF(CMAKE_CROSSCOMPILING)
     IF(DEFINED MAKE_KERNEL_ARCH)
@@ -279,30 +306,51 @@ IF(CMAKE_CROSSCOMPILING)
     ENDIF()
 ENDIF()
 
-ADD_CUSTOM_COMMAND(
-    OUTPUT ${MODULE_OUTPUT_DIR}/${MODULE_FILE}
-    COMMAND ${CMAKE_MAKE_PROGRAM} ${MAKE_KERNEL_CROSSCOMPILING_PARAMS} -C ${KERNEL_DIR} M=${MODULE_OUTPUT_DIR} modules
-    WORKING_DIRECTORY ${MODULE_OUTPUT_DIR}
-    DEPENDS ${MODULE_LINKED_SOURCE_FILES} ${TOOLS_DIR}/linux/Kbuild.in
-    VERBATIM
-)
+###############################################################################
+# Build only selected kernel modules
+###############################################################################
 
-ADD_CUSTOM_TARGET(
-    ${MODULE_NAME}
-    ALL
-    DEPENDS ${MODULE_OUTPUT_DIR}/${MODULE_FILE}
-    )
+IF(CFG_POWERLINK_EDRV_82573)
+    edrvBuild(82573)
+    SET(OPLK_CLEAN_TARGET ${OPLK_CLEAN_TARGET} module_oplk82573${MODULE_NAME_SUFFIX}_clean)
+ENDIF(CFG_POWERLINK_EDRV_82573)
 
+IF(CFG_POWERLINK_EDRV_8139)
+    edrvBuild(8139)
+    SET(OPLK_CLEAN_TARGET ${OPLK_CLEAN_TARGET} module_oplk8139${MODULE_NAME_SUFFIX}_clean)
+ENDIF(CFG_POWERLINK_EDRV_8139)
+
+IF(CFG_POWERLINK_EDRV_8255X)
+    edrvBuild(8255x)
+    SET(OPLK_CLEAN_TARGET ${OPLK_CLEAN_TARGET} module_oplk8255x${MODULE_NAME_SUFFIX}_clean)
+ENDIF(CFG_POWERLINK_EDRV_8255X)
+
+IF(CFG_POWERLINK_EDRV_I210)
+    edrvBuild(i210)
+    SET(OPLK_CLEAN_TARGET ${OPLK_CLEAN_TARGET} module_oplki210${MODULE_NAME_SUFFIX}_clean)
+ENDIF(CFG_POWERLINK_EDRV_I210)
+
+IF(CFG_POWERLINK_EDRV_8111)
+    edrvBuild(8111)
+    SET(OPLK_CLEAN_TARGET ${OPLK_CLEAN_TARGET} module_oplk8111${MODULE_NAME_SUFFIX}_clean)
+ENDIF(CFG_POWERLINK_EDRV_8111)
+
+IF(CFG_POWERLINK_EDRV_EMACPS)
+    edrvBuild(emacps)
+    SET(OPLK_CLEAN_TARGET ${OPLK_CLEAN_TARGET} module_oplk82573${MODULE_NAME_SUFFIX}_clean)
+ENDIF(CFG_POWERLINK_EDRV_EMACPS)
+
+###############################################################################
+# Clean all modules build directories
+###############################################################################
 ADD_CUSTOM_TARGET(
     module_clean
-    COMMAND ${CMAKE_MAKE_PROGRAM} -C ${KERNEL_DIR} M=${MODULE_OUTPUT_DIR} clean
-    #COMMAND ${CMAKE_COMMAND} -E remove_directory ${MODULE_OUTPUT_DIR}/src
+    COMMAND ${CMAKE_MAKE_PROGRAM} ${OPLK_CLEAN_TARGET}
     )
 
 ################################################################################
 # add installation rules
 
-INSTALL(FILES ${MODULE_OUTPUT_DIR}/${MODULE_NAME}.ko DESTINATION ${PROJECT_NAME})
 INSTALL(FILES ${TOOLS_DIR}/linux/50-openPOWERLINK.rules DESTINATION ${PROJECT_NAME})
 INSTALL(PROGRAMS ${TOOLS_DIR}/linux/plkload DESTINATION ${PROJECT_NAME})
 INSTALL(PROGRAMS ${TOOLS_DIR}/linux/plkunload DESTINATION ${PROJECT_NAME})

--- a/tools/linux/Kbuild.in
+++ b/tools/linux/Kbuild.in
@@ -3,7 +3,7 @@
 #
 
 EXTRA_CFLAGS := ${MODULE_INCLUDES}
-EXTRA_CFLAGS += ${MODULE_DEFS}
+EXTRA_CFLAGS += ${MODULE_EDRV_DEFS}
 
 # object files for kernel object with relative paths
 MODULEOBJS      = ${MODULE_OBJS}


### PR DESCRIPTION
Hello,

Use CFG_POWERLINK_EDRV as a comma serarated list of oplk kernel modules
to be build at once. Add -DCFG_POWERLINK_EDRV="82573;i210;8111;8139" to
the cmake command to build correcponding module.

The cmake build system has been modified to use a foreach loop
to build each module separately using a out of tree build.

This is useful when several ethernet interface are available
but doesn't use the same ethernet controler or for evaluation
purpose.

Best regards,
Romain