### PR TITLE
[FIX] cmake: install oplk headers files

### DIFF
--- a/stack/CMakeLists.txt
+++ b/stack/CMakeLists.txt
@@ -103,3 +103,8 @@ ELSEIF((CMAKE_SYSTEM_NAME STREQUAL "Generic") AND (CMAKE_SYSTEM_PROCESSOR STREQU
 ELSE()
     MESSAGE(FATAL_ERROR "Unknown Platform and processor combination ${CMAKE_SYSTEM_NAME} and ${CMAKE_SYSTEM_PROCESSOR}!!")
 ENDIF()
+
+################################################################################
+# Install oplk headers files
+################################################################################
+INSTALL(DIRECTORY ${STACK_INCLUDE_DIR}/oplk DESTINATION "include")


### PR DESCRIPTION
Hello,

In order to be able to link a third paries application
with openpowerlink libraries, we need to install oplk
headers files related to openpowerlink stack.

Install all headers file from STACK_INCLUDE_DIR/oplk.

Best regards,
Romain