### PR TITLE
Fix unconstrained path/port warnings on DE2-115 MN and CN designs

### DIFF
--- a/hardware/boards/terasic-de2-115/cn-dual-hostif-gpio/quartus/cnDualHostifGpio.sdc
+++ b/hardware/boards/terasic-de2-115/cn-dual-hostif-gpio/quartus/cnDualHostifGpio.sdc
@@ -45,8 +45,14 @@ set_false_path -from [get_registers *]      -to [get_ports EPCS_SDO]
 set_false_path -from [get_ports EPCS_DATA0] -to [get_registers *]
 
 # ------------------------------------------------------------------------------
+# Node switch
+# -> Cut path
+set_false_path -from [get_ports NODE_SWITCH[*]] -to [get_registers *]
+
+# ------------------------------------------------------------------------------
 # Other IOs
 set_false_path -from [get_registers *]      -to [get_ports LEDG[*]]
+set_false_path -from [get_registers *]      -to [get_ports HEX?[*]]
 set_false_path -from [get_registers *]      -to [get_ports LCD_*]
 set_false_path -from [get_registers *]      -to [get_ports LCD_DQ[*]]
 set_false_path -from [get_registers *]      -to [get_ports BENCHMARK[*]]

--- a/hardware/boards/terasic-de2-115/cn-single-hostif-drv/quartus/cnSingleHostifDrv.sdc
+++ b/hardware/boards/terasic-de2-115/cn-single-hostif-drv/quartus/cnSingleHostifDrv.sdc
@@ -40,3 +40,4 @@ set_false_path -from [get_ports EPCS_DATA0] -to [get_registers *]
 # ------------------------------------------------------------------------------
 # Other IOs
 set_false_path -from [get_registers *]      -to [get_ports HOSTIF_IRQ_n]
+set_false_path -from [get_registers *]      -to [get_ports LEDG[*]]

--- a/hardware/boards/terasic-de2-115/mn-single-hostif-drv/quartus/mnSingleHostifDrv.sdc
+++ b/hardware/boards/terasic-de2-115/mn-single-hostif-drv/quartus/mnSingleHostifDrv.sdc
@@ -37,3 +37,7 @@ set_false_path -from [get_registers *]      -to [get_ports EPCS_SCE]
 set_false_path -from [get_registers *]      -to [get_ports EPCS_SDO]
 set_false_path -from [get_ports EPCS_DATA0] -to [get_registers *]
 set_false_path -from [get_registers *]      -to [get_ports HOSTIF_IRQ_n]
+
+# ------------------------------------------------------------------------------
+# Other IOs
+set_false_path -from [get_registers *]      -to [get_ports LEDG[*]]


### PR DESCRIPTION
Due to missing constraints for the LED GPIOs, NODE_SWITCH and HEX in
Terasic DE2-115 mn-single-hostif-drv, cn-single-hostif-drv and
cn-dual-hostif-gpio designs, unconstrained paths/ports warnings are
reported in the TimeQuest Timing Analyzer.

This commit add the constraints for the LED GPIOs, NODE_SWITCH and HEX
for Terasic DE2-115 designs which resolves the unconstrained path/ports
warning during placement and routing.
