### PR TITLE
CN Objdict: fix PReq/PRes ActPayloadLimit highLimit value

### DIFF
--- a/apps/demo_cn_console/src/main.c
+++ b/apps/demo_cn_console/src/main.c
@@ -236,8 +236,8 @@ static tOplkError initPowerlink(UINT32 cycleLen_p, char* devName_p, const BYTE* 
     initParam.fAsyncOnly              = FALSE;
     initParam.featureFlags            = UINT_MAX;
     initParam.cycleLen                = cycleLen_p;       // required for error detection
-    initParam.isochrTxMaxPayload      = 36;               // const
-    initParam.isochrRxMaxPayload      = 36;               // const
+    initParam.isochrTxMaxPayload      = C_DLL_ISOCHR_MAX_PAYL; // const
+    initParam.isochrRxMaxPayload      = C_DLL_ISOCHR_MAX_PAYL; // const
     initParam.presMaxLatency          = 50000;            // const; only required for IdentRes
     initParam.preqActPayloadLimit     = 36;               // required for initialisation (+28 bytes)
     initParam.presActPayloadLimit     = 36;               // required for initialisation of Pres frame (+28 bytes)

--- a/apps/demo_cn_embedded/src/main.c
+++ b/apps/demo_cn_embedded/src/main.c
@@ -219,8 +219,8 @@ static tOplkError initPowerlink(tInstance* pInstance_p)
     initParam.fAsyncOnly              = FALSE;
     initParam.featureFlags            = -1;
     initParam.cycleLen                = pInstance_p->cycleLen;  // required for error detection
-    initParam.isochrTxMaxPayload      = 36;                     // const
-    initParam.isochrRxMaxPayload      = 36;                     // const
+    initParam.isochrTxMaxPayload      = C_DLL_ISOCHR_MAX_PAYL;  // const
+    initParam.isochrRxMaxPayload      = C_DLL_ISOCHR_MAX_PAYL;  // const
     initParam.presMaxLatency          = 2000;                   // const; only required for IdentRes
     initParam.asndMaxLatency          = 2000;                   // const; only required for IdentRes
     initParam.preqActPayloadLimit     = 36;                     // required for initialization (+28 bytes)

--- a/objdicts/CiA401_CN/00000000_POWERLINK_CiA401_CN.xdd
+++ b/objdicts/CiA401_CN/00000000_POWERLINK_CiA401_CN.xdd
@@ -1206,8 +1206,8 @@
             <SubObject subIndex="01" name="IsochrTxMaxPayload_U16" objectType="7" dataType="0006" accessType="const" PDOmapping="no" defaultValue="36"/>
             <SubObject subIndex="02" name="IsochrRxMaxPayload_U16" objectType="7" dataType="0006" accessType="const" PDOmapping="no" defaultValue="36"/>
             <SubObject subIndex="03" name="PResMaxLatency_U32" objectType="7" dataType="0007" accessType="const" PDOmapping="no" defaultValue="2000"/>
-            <SubObject subIndex="04" name="PReqActPayloadLimit_U16" objectType="7" dataType="0006" accessType="rw" PDOmapping="no" lowLimit="36" highLimit="36" defaultValue="36"/>
-            <SubObject subIndex="05" name="PResActPayloadLimit_U16" objectType="7" dataType="0006" accessType="rw" PDOmapping="no" lowLimit="36" highLimit="36" defaultValue="36"/>
+            <SubObject subIndex="04" name="PReqActPayloadLimit_U16" objectType="7" dataType="0006" accessType="rw" PDOmapping="no" lowLimit="36" highLimit="1490" defaultValue="36"/>
+            <SubObject subIndex="05" name="PResActPayloadLimit_U16" objectType="7" dataType="0006" accessType="rw" PDOmapping="no" lowLimit="36" highLimit="1490" defaultValue="36"/>
             <SubObject subIndex="06" name="ASndMaxLatency_U32" objectType="7" dataType="0007" accessType="const" PDOmapping="no" defaultValue="2000"/>
             <SubObject subIndex="07" name="MultiplCycleCnt_U8" objectType="7" dataType="0005" accessType="rw" PDOmapping="no" defaultValue="0"/>
             <SubObject subIndex="08" name="AsyncMTU_U16" objectType="7" dataType="0006" accessType="rw" PDOmapping="no" lowLimit="300" highLimit="1500" defaultValue="300"/>


### PR DESCRIPTION
As reported in [1], the highLimit value for PReq/PRes ActPayloadLimit is wrong.
The bug appear with OC >= 2.0.0.

[1] https://sourceforge.net/p/openconf/discussion/help/thread/29fffde5/#5160

Signed-off-by: Romain Naour <romain.naour@openwide.fr>