### PR TITLE
[FIX] fix EntrySize for REAL32 datatype

### DIFF
--- a/stack/src/user/api/processimage-cia302.c
+++ b/stack/src/user/api/processimage-cia302.c
@@ -102,7 +102,7 @@ tProcessImageLink processImageLink_l[] =
     { 0xA100,   0xA107,     0,      FALSE,      2,      PI_SUBINDEX_COUNT },
     { 0xA1C0,   0xA1C3,     0,      FALSE,      4,      PI_SUBINDEX_COUNT },
     { 0xA200,   0xA203,     0,      FALSE,      4,      PI_SUBINDEX_COUNT },
-    { 0xA240,   0xA247,     0,      FALSE,      8,      PI_SUBINDEX_COUNT },
+    { 0xA240,   0xA247,     0,      FALSE,      4,      PI_SUBINDEX_COUNT },
     { 0xA400,   0xA401,     0,      FALSE,      8,      PI_SUBINDEX_COUNT },
     { 0xA440,   0xA441,     0,      FALSE,      8,      PI_SUBINDEX_COUNT },
     { 0xA480,   0xA48F,     0,      TRUE,       1,      PI_SUBINDEX_COUNT },
@@ -111,7 +111,7 @@ tProcessImageLink processImageLink_l[] =
     { 0xA580,   0xA587,     0,      TRUE,       2,      PI_SUBINDEX_COUNT },
     { 0xA640,   0xA643,     0,      TRUE,       4,      PI_SUBINDEX_COUNT },
     { 0xA680,   0xA683,     0,      TRUE,       4,      PI_SUBINDEX_COUNT },
-    { 0xA6C0,   0xA6C7,     0,      TRUE,       8,      PI_SUBINDEX_COUNT },
+    { 0xA6C0,   0xA6C7,     0,      TRUE,       4,      PI_SUBINDEX_COUNT },
     { 0xA880,   0xA881,     0,      TRUE,       8,      PI_SUBINDEX_COUNT },
     { 0xA8C0,   0xA8C1,     0,      TRUE,       8,      PI_SUBINDEX_COUNT }
 };


### PR DESCRIPTION
The commit f9a4a53bafea2b8bc3053d5537e9ecef89f049bb introduce a runtime bug [1]
due to a typo in processImageLink_l[] tab.

A REAL32 is 4 bytes (tObdReal32) in size, not 8.

[1] "oplk_setupProcessImage() failed with "Value to write is too long or too short" (0x003a)"

Signed-off-by: Romain Naour <romain.naour@openwide.fr>