### PR TITLE
[FIX] oplkcfg.h: Remove configuration option CONFIG_OBD_USE_LOAD_CONC…

### DIFF
--- a/stack/proj/linux/liboplkmnapp-kernelpcie/oplkcfg.h
+++ b/stack/proj/linux/liboplkmnapp-kernelpcie/oplkcfg.h
@@ -102,9 +102,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // callback function (called event kObdEvWrStringDomain)
 #define CONFIG_OBD_USE_STRING_DOMAIN_IN_RAM             TRUE
 
-#define CONFIG_OBD_USE_LOAD_CONCISEDCF                  TRUE
+#if defined(CONFIG_INCLUDE_CFM)
 #define CONFIG_OBD_DEF_CONCISEDCF_FILENAME              "mnobd.cdc"
 #define CONFIG_CFM_CONFIGURE_CYCLE_LENGTH               TRUE
+#endif
 
 // Configure if the range from 0xA000 is used for mapping client objects.
 // openCONFIGURATOR uses this range for mapping objects.

--- a/stack/proj/windows/liboplkmnapp-kernelintf/oplkcfg.h
+++ b/stack/proj/windows/liboplkmnapp-kernelintf/oplkcfg.h
@@ -82,9 +82,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // callback function (called event kObdEvWrStringDomain)
 #define CONFIG_OBD_USE_STRING_DOMAIN_IN_RAM         TRUE
 
-#define CONFIG_OBD_USE_LOAD_CONCISEDCF              TRUE
+#if defined(CONFIG_INCLUDE_CFM)
 #define CONFIG_OBD_DEF_CONCISEDCF_FILENAME          "mnobd.cdc"
 #define CONFIG_CFM_CONFIGURE_CYCLE_LENGTH           TRUE
+#endif
 
 // Configure if the range from 0xA000 is used for mapping client objects.
 // openCONFIGURATOR uses this range for mapping objects.

--- a/stack/proj/windows/liboplkmnapp-pcieintf/oplkcfg.h
+++ b/stack/proj/windows/liboplkmnapp-pcieintf/oplkcfg.h
@@ -82,9 +82,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // callback function (called event kObdEvWrStringDomain)
 #define CONFIG_OBD_USE_STRING_DOMAIN_IN_RAM         TRUE
 
-#define CONFIG_OBD_USE_LOAD_CONCISEDCF              TRUE
+#if defined(CONFIG_INCLUDE_CFM)
 #define CONFIG_OBD_DEF_CONCISEDCF_FILENAME          "mnobd.cdc"
 #define CONFIG_CFM_CONFIGURE_CYCLE_LENGTH           TRUE
+#endif
 
 // Configure if the range from 0xA000 is used for mapping client objects.
 // openCONFIGURATOR uses this range for mapping objects.


### PR DESCRIPTION
…ISEDCF

The commit 97704aaa7b7ffdbfb02ac3bff5a253bb1b6c3f37 removed the configuration
option CONFIG_OBD_USE_LOAD_CONCISEDCF in develop-2.2 but not in develop-2.3.

Signed-off-by: Romain Naour <romain.naour@gmail.com>