### PR TITLE
[FIX] PCIe Driver: Disable Werror=date-time for kernel >= 3.14

### DIFF
--- a/drivers/linux/drv_kernelmod_pcie/CMakeLists.txt
+++ b/drivers/linux/drv_kernelmod_pcie/CMakeLists.txt
@@ -45,6 +45,9 @@ MESSAGE(STATUS "CMAKE_SYSTEM_PROCESSOR is ${CMAKE_SYSTEM_PROCESSOR}")
 STRING(TOLOWER "${CMAKE_SYSTEM_NAME}" SYSTEM_NAME_DIR)
 STRING(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" SYSTEM_PROCESSOR_DIR)
 
+# Since 3.14 kernel Werror=date-time is automatically used if the compiler supports it.
+SET(MODULE_DEFS "${MODULE_DEFS} -Wno-date-time")
+
 ################################################################################
 # Configuration options
 


### PR DESCRIPTION
Avoid a build error due to __DATE__ and __TIME___ being used in
oplk driver. Just disable the warning with -Wno-date-time.

See da76c94059ed799689ad3283ddcb32d5ace175a0

Signed-off-by: Romain Naour <romain.naour@gmail.com>