### PR TITLE
[FIX] apps: include stdarg.h in eventlogstring.h

### DIFF
--- a/apps/common/src/eventlog/eventlog.c
+++ b/apps/common/src/eventlog/eventlog.c
@@ -47,7 +47,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //------------------------------------------------------------------------------
 
 #include <stdio.h>
-#include <stdarg.h>
 #include <time.h>
 
 #include <oplk/debugstr.h>

--- a/apps/common/src/eventlog/eventlogstring.c
+++ b/apps/common/src/eventlog/eventlogstring.c
@@ -47,7 +47,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "eventlogstring.h"
 
 #include <stdio.h>
-#include <stdarg.h>
 #include <time.h>
 
 #include <oplk/debugstr.h>

--- a/apps/common/src/eventlog/eventlogstring.h
+++ b/apps/common/src/eventlog/eventlogstring.h
@@ -41,6 +41,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //------------------------------------------------------------------------------
 // includes
 //------------------------------------------------------------------------------
+#include <stdarg.h>
+
 #include <oplk/oplk.h>
 #include <oplk/nmt.h>
 


### PR DESCRIPTION
va_list type is used in eventlogstring.h so stdarg.h must be included to define
it.

This problem occurs with a uClibc-ng based toolchain.

Fixes:
http://autobuild.buildroot.net/results/a9e/a9e7615a19922706039bf97ccb94bcf5b99330b2/build-end.log

Signed-off-by: Romain Naour <romain.naour@gmail.com>