### PR TITLE
[TASK] openmac-nios2: use alt_irq_pending() only with internal interr…

### DIFF
--- a/stack/include/oplk/targetdefs/nios2.h
+++ b/stack/include/oplk/targetdefs/nios2.h
@@ -122,5 +122,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define OPLK_MUTEX_T    alt_u8
 
+#ifdef NIOS2_EIC_PRESENT
+#if defined(__ALTERA_VIC)
+#include <altera_vic_regs.h>
+#endif
+#endif
+
 #endif /* _INC_targetdefs_nios2_H_ */
 

--- a/stack/include/target/openmac-nios2.h
+++ b/stack/include/target/openmac-nios2.h
@@ -63,7 +63,16 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define OPENMAC_FLUSHDATACACHE(pMem_p, size_p)
 #define OPENMAC_INVALIDATEDATACACHE(pMem_p, size_p)
 #define OPENMAC_GETDMAOBSERVER()                            IORD_16DIRECT(OPENMAC_DOB_BASE, 0)
+
+#if defined(NIOS2_EIC_PRESENT)
+/* Only an External Interruption Controller with a Vectored Interrupt Controller (named vic_0) on PCP processor is supported. */
+#if defined(__ALTERA_VIC) && !defined(PCP_0_VIC_0_BASE)
+#error "Currently only vic_0 on pcp_0 is supported."
+#endif
+#define OPENMAC_GETPENDINGIRQ()                             IORD_ALTERA_VIC_INT_PENDING(PCP_0_VIC_0_BASE)
+#else
 #define OPENMAC_GETPENDINGIRQ()                             alt_irq_pending()
+#endif
 
 #define OPENMAC_TIMER_OFFSET(timer_p)                       (timer_p << 4)
 


### PR DESCRIPTION
…upt controller

In commit 55959ef alt_irq_pending() is used directly by OPENMAC_GETPENDINGIRQ()
macro but alt_irq_pending() is not defined when an EIC
(External Interrupt Controller) is used.

The EIC can be connected to an Altera VIC (Vectored Interrupt Controller) which
provide IORD_ALTERA_VIC_INT_PENDING() macro to show the pending interrupts. This
macro return the INT_PENDING register value from the csr [1].

Since this macro is desgin dependent, only allow EIC when used with a VIC named
vic_0 on processor pcp_0.

[1] see P 331 up_embedded_ip.pdf

Signed-off-by: Romain Naour <romain.naour@gmail.com>
---
v2: use positive logic for NIOS2_EIC_PRESENT test.
    hardcode pcp_0 and vic_0 name (PCP_0_VIC_0_BASE)