### PR TITLE
[FIX] Allow to remove benchmark IP from Nios2 design

### DIFF
--- a/drivers/altera-nios2/drv_daemon/daemon.c
+++ b/drivers/altera-nios2/drv_daemon/daemon.c
@@ -44,7 +44,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <system.h>
 #include <sys/alt_cache.h>
 #include <unistd.h>
-#include <altera_avalon_pio_regs.h>
 
 #include <oplk/oplk.h>
 #include <oplk/debugstr.h>

--- a/stack/src/arch/altera-nios2/target-nios2.c
+++ b/stack/src/arch/altera-nios2/target-nios2.c
@@ -46,7 +46,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <common/oplkinc.h>
 #include <common/target.h>
 #include <system.h>
-#include <altera_avalon_pio_regs.h>
 
 //============================================================================//
 //            G L O B A L   D E F I N I T I O N S                             //
@@ -61,6 +60,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define GPIO_ERROR_LED_BIT      2
 
 #ifdef PCP_0_POWERLINK_LED_BASE
+#include <altera_avalon_pio_regs.h>
 #define TARGET_POWERLINK_LED_BASE PCP_0_POWERLINK_LED_BASE
 #endif
 


### PR DESCRIPTION
When a cn_pcp.qys design is customized, the benchmark (debug) IP may not be instantiated.

Add a guard around altera_avalon_pio_regs.h include to cover this use case.

Since POWERLINK_LED depends on benchmark IP, error out cleanly when POWERLINK_LED is set
without BENCHMARK_PIO.

Signed-off-by: Romain Naour <romain.naour@gmail.com>