### PR TITLE
Fix for Dualprocshm compiler warnings

### DIFF
--- a/contrib/dualprocshm/include/dualprocshm-arm.h
+++ b/contrib/dualprocshm/include/dualprocshm-arm.h
@@ -44,6 +44,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 #include <unistd.h>
 
 #include <xil_cache.h>

--- a/contrib/dualprocshm/include/dualprocshm-arm.h
+++ b/contrib/dualprocshm/include/dualprocshm-arm.h
@@ -9,7 +9,7 @@ This header file provides specific macros for Zynq ARM CPU.
 *******************************************************************************/
 
 /*------------------------------------------------------------------------------
-Copyright (c) 2015, Kalycito Infotech Private Limited
+Copyright (c) 2016, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -44,7 +44,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdio.h>
+#include <unistd.h>
+
 #include <xil_cache.h>
 #include <xscugic.h>
 #include <xil_exception.h>

--- a/contrib/dualprocshm/include/dualprocshm-c5socarm.h
+++ b/contrib/dualprocshm/include/dualprocshm-c5socarm.h
@@ -44,6 +44,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 #include <unistd.h>
 
 #include <system.h>
@@ -63,6 +64,14 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //------------------------------------------------------------------------------
 // const defines
 //------------------------------------------------------------------------------
+
+#ifndef TRACE
+#ifndef NDEBUG
+#define TRACE(...)                      printf(__VA_ARGS__)
+#else
+#define TRACE(...)
+#endif
+#endif
 
 // memory
 #define DPSHM_MAKE_NONCACHEABLE(ptr)    (void*)(((unsigned long)ptr))
@@ -159,14 +168,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define DPSHM_CONNECT_SYNC_IRQ()
 #define DPSHM_DISCONNECT_SYNC_IRQ()
-
-#ifndef TRACE
-#ifndef NDEBUG
-#define TRACE(...)                      printf(__VA_ARGS__)
-#else
-#define TRACE(...)
-#endif
-#endif
 
 //------------------------------------------------------------------------------
 // typedef

--- a/contrib/dualprocshm/include/dualprocshm-c5socarm.h
+++ b/contrib/dualprocshm/include/dualprocshm-c5socarm.h
@@ -9,7 +9,7 @@ This header file provides specific macros for Altera Cyclone V SoC ARM CPU.
 *******************************************************************************/
 
 /*------------------------------------------------------------------------------
-Copyright (c) 2015 Kalycito Infotech Private Limited
+Copyright (c) 2016 Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -64,14 +64,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // const defines
 //------------------------------------------------------------------------------
 
-#ifndef TRACE
-#ifndef NDEBUG
-#define TRACE(...)                      printf(__VA_ARGS__)
-#else
-#define TRACE(...)
-#endif
-#endif
-
 // memory
 #define DPSHM_MAKE_NONCACHEABLE(ptr)    (void*)(((unsigned long)ptr))
 #define DUALPROCSHM_MALLOC(size)        malloc(size)
@@ -99,19 +91,21 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // cache handling
 #ifdef ALTARM_CACHE_ENABLE
-#define DUALPROCSHM_FLUSH_DCACHE_RANGE(base, range)                                                                                         \
-    ({                                                                                                                                      \
+#define DUALPROCSHM_FLUSH_DCACHE_RANGE(base, range)                                                                                         \                                                                                        \
+     do                                                                                                                                     \
+     {                                                                                                                                      \
          UINT32 tempBase = (UINT32)(((UINT32)base) & ~((UINT32)CACHE_ALIGNED_BYTE_CHECK));                                                  \
          UINT32 tempCeil = (UINT32)((((UINT32)base + (UINT32)range) + CACHE_ALIGNED_BYTE_CHECK) & ~((UINT32)CACHE_ALIGNED_BYTE_CHECK));     \
          alt_cache_system_clean((void*)tempBase, (size_t)(tempCeil - tempBase));                                                            \
-     })
+     } while (0)
 
 #define DUALPROCSHM_INVALIDATE_DCACHE_RANGE(base, range)                                                                                    \
-    ({                                                                                                                                      \
+     do                                                                                                                                     \
+     {                                                                                                                                      \
          UINT32 tempBase = (UINT32)(((UINT32)base) & ~((UINT32)CACHE_ALIGNED_BYTE_CHECK));                                                  \
          UINT32 tempCeil = (UINT32)((((UINT32)base + (UINT32)range) + CACHE_ALIGNED_BYTE_CHECK) & ~((UINT32)CACHE_ALIGNED_BYTE_CHECK));     \
          alt_cache_system_invalidate((void*)tempBase, (size_t)(tempCeil - tempBase));                                                       \
-     })
+     } while (0)
 #else
 
 #define DUALPROCSHM_FLUSH_DCACHE_RANGE(base, range)
@@ -130,52 +124,49 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define DPSHM_CLEAR_SYNC_IRQ()                  alt_int_dist_pending_clear(SYNC_IRQ)
 
 #define DPSHM_ENABLE_SYNC_INTR()                                                              \
-    ({                                                                                        \
-         int ret = 0;                                                                         \
+    do                                                                                        \
+    {                                                                                         \
          alt_int_dist_pending_clear(SYNC_IRQ);                                                \
                                                                                               \
          if (alt_int_dist_target_set(SYNC_IRQ, TARGET_CPU) != ALT_E_SUCCESS)                  \
          {                                                                                    \
-             ret = -1;                                                                        \
              TRACE("Sync IRQ target cpu set failed\n");                                       \
          }                                                                                    \
          else                                                                                 \
          {                                                                                    \
-             if (alt_int_dist_trigger_set(SYNC_IRQ, ALT_INT_TRIGGER_EDGE) != ALT_E_SUCCESS)  \
+             if (alt_int_dist_trigger_set(SYNC_IRQ, ALT_INT_TRIGGER_EDGE) != ALT_E_SUCCESS)   \
              {                                                                                \
-                 ret = -1;                                                                    \
                  TRACE("Sync IRQ trigger set failed\n");                                      \
              }                                                                                \
              else                                                                             \
              {                                                                                \
                  if (alt_int_dist_enable(SYNC_IRQ) != ALT_E_SUCCESS)                          \
                  {                                                                            \
-                     /* Set interrupt distributor target */                                   \
-                     ret = -1;                                                                \
                      TRACE("Sync IRQ could not be enabled in the distributor\n");             \
                  }                                                                            \
-                                                                                              \
              }                                                                                \
          }                                                                                    \
-                                                                                              \
-         ret;                                                                                 \
-     })
+     } while (0)
 
 #define DPSHM_DISABLE_SYNC_INTR()                                          \
-    ({                                                                     \
-         int ret = 0;                                                      \
+    do                                                                     \
+    {                                                                      \
          if (alt_int_dist_disable(SYNC_IRQ) != ALT_E_SUCCESS)              \
          {                                                                 \
-             /* access to any FPGA registers if required */                \
-             ret = -1;                                                     \
              TRACE("Sync IRQ could not be disabled in the distributor\n"); \
          }                                                                 \
-                                                                           \
-         ret;                                                              \
-     })
+     } while (0)
 
 #define DPSHM_CONNECT_SYNC_IRQ()
 #define DPSHM_DISCONNECT_SYNC_IRQ()
+
+#ifndef TRACE
+#ifndef NDEBUG
+#define TRACE(...)                      printf(__VA_ARGS__)
+#else
+#define TRACE(...)
+#endif
+#endif
 
 //------------------------------------------------------------------------------
 // typedef

--- a/contrib/dualprocshm/include/dualprocshm-microblaze.h
+++ b/contrib/dualprocshm/include/dualprocshm-microblaze.h
@@ -44,6 +44,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 #include <unistd.h>
 
 #include <xil_types.h>

--- a/contrib/dualprocshm/include/dualprocshm-microblaze.h
+++ b/contrib/dualprocshm/include/dualprocshm-microblaze.h
@@ -9,7 +9,7 @@ This header file provides specific macros for Xilinx Microblaze CPU.
 *******************************************************************************/
 
 /*------------------------------------------------------------------------------
-Copyright (c) 2015, Kalycito Infotech Private Limited
+Copyright (c) 2016, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -42,8 +42,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // includes
 //------------------------------------------------------------------------------
 #include <stdint.h>
-#include <stddef.h>
-#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
 #include <xil_types.h>
 #include <xil_cache.h>
 #include <xintc_l.h>

--- a/contrib/dualprocshm/include/dualprocshm-nios2.h
+++ b/contrib/dualprocshm/include/dualprocshm-nios2.h
@@ -120,24 +120,15 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define DUALPROCSHM_INVALIDATE_DCACHE_RANGE(base, range) \
     ((void)0)
 
-#define DPSHM_REG_SYNC_INTR(pfnIrqCb_p, pArg_p)                     \
-    do                                                              \
-    {                                                               \
-        alt_ic_isr_register(TARGET_SYNC_IRQ_ID, TARGET_SYNC_IRQ,    \
-                            pfnIrqCb_p, pArg_p, NULL);              \
-    } while (0)
+#define DPSHM_REG_SYNC_INTR(pfnIrqCb_p, pArg_p) \
+    UNUSED_PARAMETER(pfnIrqCb_p);               \
+    UNUSED_PARAMETER(pArg_p)
 
-#define DPSHM_ENABLE_SYNC_INTR()                                    \
-    do                                                              \
-    {                                                               \
-        alt_ic_irq_enable(TARGET_SYNC_IRQ_ID, TARGET_SYNC_IRQ);     \
-    } while (0)
+#define DPSHM_ENABLE_SYNC_INTR() \
+        alt_ic_irq_enable(TARGET_SYNC_IRQ_ID, TARGET_SYNC_IRQ)
 
-#define DPSHM_DISABLE_SYNC_INTR()                                   \
-    do                                                              \
-    {                                                               \
-        alt_ic_irq_disable(TARGET_SYNC_IRQ_ID, TARGET_SYNC_IRQ);    \
-    } while (0)
+#define DPSHM_DISABLE_SYNC_INTR() \
+        alt_ic_irq_disable(TARGET_SYNC_IRQ_ID, TARGET_SYNC_IRQ)
 
 #ifndef TRACE
 #ifndef NDEBUG


### PR DESCRIPTION
Update dualprocshm target header files for Zynq and C5SOC to
resolve compiler warnings reported in https://github.com/OpenAutomationTechnologies/openPOWERLINK_V2/issues/132