### PR TITLE
[FIX] remove Veth code from kernel module if Veth support is disabled

### DIFF
--- a/stack/src/kernel/veth/veth-generic.c
+++ b/stack/src/kernel/veth/veth-generic.c
@@ -46,6 +46,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <kernel/dllk.h>
 #include <kernel/dllkcal.h>
 
+#if defined(CONFIG_INCLUDE_VETH)
 //============================================================================//
 //            G L O B A L   D E F I N I T I O N S                             //
 //============================================================================//
@@ -176,3 +177,5 @@ static tOplkError receiveFrameCb(tFrameInfo* pFrameInfo_p,
 }
 
 /// \}
+
+#endif // CONFIG_INCLUDE_VETH

--- a/stack/src/kernel/veth/veth-linuxkernel.c
+++ b/stack/src/kernel/veth/veth-linuxkernel.c
@@ -46,6 +46,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <kernel/dllk.h>
 #include <kernel/dllkcal.h>
 
+#if defined(CONFIG_INCLUDE_VETH)
 #include <net/arp.h>
 #include <net/protocol.h>
 #include <net/pkt_sched.h>
@@ -398,3 +399,5 @@ Exit:
 }
 
 /// \}
+
+#endif // CONFIG_INCLUDE_VETH

--- a/stack/src/kernel/veth/veth-linuxpcie.c
+++ b/stack/src/kernel/veth/veth-linuxpcie.c
@@ -391,4 +391,5 @@ Exit:
 }
 
 /// \}
-#endif
+
+#endif // CONFIG_INCLUDE_VETH

--- a/stack/src/kernel/veth/veth-linuxuser.c
+++ b/stack/src/kernel/veth/veth-linuxuser.c
@@ -45,6 +45,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <kernel/dllk.h>
 #include <kernel/dllkcal.h>
 
+#if defined(CONFIG_INCLUDE_VETH)
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -360,3 +361,5 @@ static void* vethRecvThread(void* pArg_p)
 }
 
 /// \}
+
+#endif // CONFIG_INCLUDE_VETH

--- a/stack/src/kernel/veth/veth-ndisintemediate.c
+++ b/stack/src/kernel/veth/veth-ndisintemediate.c
@@ -50,7 +50,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <ndisintermediate/ndis-im.h>
 
-
+#if defined(CONFIG_INCLUDE_VETH)
 //============================================================================//
 //            G L O B A L   D E F I N I T I O N S                             //
 //============================================================================//
@@ -226,3 +226,5 @@ static tOplkError veth_receiveFrame(tFrameInfo* pFrameInfo_p,
 }
 
 /// \}
+
+#endif // CONFIG_INCLUDE_VETH


### PR DESCRIPTION
The openpowerlink driver build system doesn't take into account the
stack configuration (oplkcfg.h) to remove veth-linuxuser.c file from
MODULE_SOURCE_FILES.

Thus, the Veth code is still present in generated kernel module.

Add a guard in veth-linuxuser.c to hide the code if CONFIG_INCLUDE_VETH
is not set.

Signed-off-by: Romain Naour <romain.naour@smile.fr>