### PR TITLE
[FIX] call pthread_setname_np() from the thread to be renamed

### DIFF
--- a/apps/common/src/system/system-linux.c
+++ b/apps/common/src/system/system-linux.c
@@ -266,10 +266,6 @@ void system_startSyncThread(tSyncCb pfnSync_p)
         fprintf(stderr, "pthread_create() failed with \"%d\"\n", ret);
         return;
     }
-
-#if (defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 12)
-    pthread_setname_np(syncThreadId_l, "oplkdemo-sync");
-#endif
 }
 
 //------------------------------------------------------------------------------
@@ -330,6 +326,10 @@ This function implements the synchronous application thread.
 static void* powerlinkSyncThread(void* arg)
 {
     tSyncThreadInstance*     pSyncThreadInstance = (tSyncThreadInstance*)arg;
+
+#if (defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 12)
+    pthread_setname_np(pthread_self(), "oplkdemo-sync");
+#endif
 
     printf("Synchronous data thread is starting...\n");
     while (!pSyncThreadInstance->fTerminate)

--- a/stack/src/kernel/edrv/edrv-pcap_linux.c
+++ b/stack/src/kernel/edrv/edrv-pcap_linux.c
@@ -205,10 +205,6 @@ tOplkError edrv_init(tEdrvInitParam* pEdrvInitParam_p)
                                 __func__);
     }
 
-#if (defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 12)
-    pthread_setname_np(edrvInstance_l.hThread, "oplk-edrvpcap");
-#endif
-
     /* wait until thread is started */
     sem_wait(&edrvInstance_l.syncSem);
 
@@ -553,6 +549,10 @@ static void* workerThread(void* pArgument_p)
     tEdrvInstance*  pInstance = (tEdrvInstance*)pArgument_p;
     int             pcapRet;
     char            errorMessage[PCAP_ERRBUF_SIZE];
+
+#if (defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 12)
+    pthread_setname_np(pthread_self(), "oplk-edrvpcap");
+#endif
 
     DEBUG_LVL_EDRV_TRACE("%s(): ThreadId:%ld\n", __func__, syscall(SYS_gettid));
 

--- a/stack/src/kernel/event/eventkcal-linux.c
+++ b/stack/src/kernel/event/eventkcal-linux.c
@@ -165,10 +165,6 @@ tOplkError eventkcal_init(void)
                __func__, schedParam.sched_priority);
     }
 
-#if (defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 12)
-    pthread_setname_np(instance_l.threadId, "oplk-eventk");
-#endif
-
     instance_l.fInitialized = TRUE;
     return kErrorOk;
 
@@ -317,6 +313,10 @@ static void* eventThread(void* arg)
 {
     struct timespec         curTime, timeout;
     tEventkCalInstance*     pInstance = (tEventkCalInstance*)arg;
+
+#if (defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 12)
+    pthread_setname_np(pthread_self(), "oplk-eventk");
+#endif
 
     while (!pInstance->fStopThread)
     {

--- a/stack/src/kernel/timer/hrestimer-posix.c
+++ b/stack/src/kernel/timer/hrestimer-posix.c
@@ -179,10 +179,6 @@ tOplkError hrestimer_init(void)
         return kErrorNoResource;
     }
 
-#if (defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 12)
-    pthread_setname_np(hresTimerInstance_l.threadId, "oplk-hrtimer");
-#endif
-
     return ret;
 }
 
@@ -461,6 +457,10 @@ static void* timerThread(void* pParm_p)
     siginfo_t                           signalInfo;
 
     UNUSED_PARAMETER(pParm_p);
+
+#if (defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 12)
+    pthread_setname_np(pthread_self(), "oplk-hrtimer");
+#endif
 
     DEBUG_LVL_TIMERH_TRACE("%s(): ThreadId:%ld\n", __func__, syscall(SYS_gettid));
 

--- a/stack/src/kernel/timer/hrestimer-posix_clocknanosleep.c
+++ b/stack/src/kernel/timer/hrestimer-posix_clocknanosleep.c
@@ -199,10 +199,6 @@ tOplkError hrestimer_init(void)
             pthread_cancel(pTimerInfo->timerThreadId);
             return kErrorNoResource;
         }
-
-#if (defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 12)
-        pthread_setname_np(pTimerInfo->timerThreadId, "oplk-hrtimer");
-#endif
     }
 
     return ret;
@@ -463,6 +459,10 @@ static void* timerThread(void* pArgument_p)
     tTimerHdl                   timerHdl;
 #ifdef HIGH_RESK_TIMER_LATENCY_DEBUG
     struct timespec             debugtime, curTime;
+#endif
+
+#if (defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 12)
+        pthread_setname_np(pthread_self(), "oplk-hrtimer");
 #endif
 
     DEBUG_LVL_TIMERH_TRACE("%s(): ThreadId:%ld\n", __func__, syscall(SYS_gettid));

--- a/stack/src/kernel/veth/veth-linuxuser.c
+++ b/stack/src/kernel/veth/veth-linuxuser.c
@@ -174,10 +174,6 @@ tOplkError veth_init(const UINT8 aSrcMac_p[6])
     if (pthread_create(&vethInstance_l.threadHandle, NULL, vethRecvThread, (void*)&vethInstance_l) != 0)
         return kErrorNoFreeInstance;
 
-#if (defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 12)
-    pthread_setname_np(vethInstance_l.threadHandle, "oplk-veth");
-#endif
-
     // register callback function in DLL
     ret = dllk_regAsyncHandler(veth_receiveFrame);
 
@@ -311,6 +307,10 @@ static void* vethRecvThread(void* pArg_p)
     fd_set              readFds;
     int                 result;
     struct timeval      timeout;
+
+#if (defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 12)
+    pthread_setname_np(pthread_self(), "oplk-veth");
+#endif
 
     while (!pInstance->fStop)
     {

--- a/stack/src/user/event/eventucal-linux.c
+++ b/stack/src/user/event/eventucal-linux.c
@@ -163,10 +163,6 @@ tOplkError eventucal_init(void)
                               __func__, schedParam.sched_priority);
     }
 
-#if (defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 12)
-    pthread_setname_np(instance_l.threadId, "oplk-eventu");
-#endif
-
     instance_l.fInitialized = TRUE;
     return kErrorOk;
 
@@ -320,6 +316,10 @@ static void* eventThread(void* arg)
 {
     struct timespec         curTime, timeout;
     tEventuCalInstance*     pInstance = (tEventuCalInstance*)arg;
+
+#if (defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 12)
+    pthread_setname_np(pthread_self(), "oplk-eventu");
+#endif
 
     while (!pInstance->fStopThread)
     {

--- a/stack/src/user/event/eventucal-linuxioctl.c
+++ b/stack/src/user/event/eventucal-linuxioctl.c
@@ -152,10 +152,6 @@ tOplkError eventucal_init(void)
                               __func__, schedParam.sched_priority);
     }
 
-#if (defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 12)
-    pthread_setname_np(instance_l.threadId, "oplk-eventu");
-#endif
-
 Exit:
     return ret;
 }
@@ -307,6 +303,10 @@ static void* eventThread(void* arg_p)
     char        eventBuf[sizeof(tEvent) + MAX_EVENT_ARG_SIZE];
 
     UNUSED_PARAMETER(arg_p);
+
+#if (defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 12)
+    pthread_setname_np(pthread_self(), "oplk-eventu");
+#endif
 
     pEvent = (tEvent*)eventBuf;
 

--- a/stack/src/user/event/eventucal-linuxpcie.c
+++ b/stack/src/user/event/eventucal-linuxpcie.c
@@ -169,10 +169,6 @@ tOplkError eventucal_init(void)
                               __func__, schedParam.sched_priority);
     }
 
-#if (defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 12)
-    pthread_setname_np(instance_l.kernelEventThreadId, "oplk-eventufetch");
-#endif
-
     // Create thread for processing pending user data
     if (pthread_create(&instance_l.processEventThreadId, NULL, eventProcessThread, NULL) != 0)
         goto Exit;
@@ -184,9 +180,6 @@ tOplkError eventucal_init(void)
                               __func__, schedParam.sched_priority);
     }
 
-#if (defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 12)
-    pthread_setname_np(instance_l.processEventThreadId, "oplk-eventuprocess");
-#endif
     instance_l.fInitialized = TRUE;
     return kErrorOk;
 
@@ -370,6 +363,10 @@ static void* k2uEventFetchThread(void* pArg_p)
 
     UNUSED_PARAMETER(pArg_p);
 
+#if (defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 12)
+    pthread_setname_np(pthread_self(), "oplk-eventufetch");
+#endif
+
     while (!instance_l.fStopKernelThread)
     {
         ret = ioctl(instance_l.fd, PLK_CMD_GET_EVENT, pEvent);
@@ -419,6 +416,10 @@ static void* eventProcessThread(void* pArg_p)
     struct timespec         timeout;
 
     UNUSED_PARAMETER(pArg_p);
+
+#if (defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 12)
+    pthread_setname_np(pthread_self(), "oplk-eventuprocess");
+#endif
 
     while (!instance_l.fStopProcessThread)
     {

--- a/stack/src/user/sdo/sdoudp-linux.c
+++ b/stack/src/user/sdo/sdoudp-linux.c
@@ -187,10 +187,6 @@ tOplkError sdoudp_createSocket(tSdoUdpCon* pSdoUdpCon_p)
     if (pthread_create(&instance_l.threadHandle, NULL, sdoUdpThread, (void*)&instance_l) != 0)
         return kErrorSdoUdpThreadError;
 
-#if (defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 12)
-    pthread_setname_np(instance_l.threadHandle, "oplk-sdoudp");
-#endif
-
     return kErrorOk;
 }
 
@@ -353,6 +349,10 @@ static tThreadResult sdoUdpThread(tThreadArg pArg_p)
     fd_set                  readFds;
     int                     result;
     struct timeval          timeout;
+
+#if (defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 12)
+    pthread_setname_np(pthread_self(), "oplk-sdoudp");
+#endif
 
     pInstance = (tSdoUdpSocketInstance*)pArg_p;
 

--- a/stack/src/user/timer/timer-linuxuser.c
+++ b/stack/src/user/timer/timer-linuxuser.c
@@ -163,10 +163,6 @@ tOplkError timeru_init(void)
                                 __func__);
     }
 
-#if (defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 12)
-    pthread_setname_np(timeruInstance_g.processThread, "oplk-timeru");
-#endif
-
     return kErrorOk;
 }
 
@@ -467,6 +463,10 @@ static void* processThread(void* pArgument_p)
     siginfo_t       signalInfo;
 
     UNUSED_PARAMETER(pArgument_p);
+
+#if (defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 12)
+    pthread_setname_np(pthread_self(), "oplk-timeru");
+#endif
 
     // Uncomment to show the thread ID on Linux (include must also be uncommented)!
     // DEBUG_LVL_TIMERU_TRACE("%s() ThreadId:%d\n", __func__, syscall(SYS_gettid));


### PR DESCRIPTION
pthread_setname_np() must be used from the thread to be renamed
otherwise the new name will not be accepted when the openPOWERLINK
application is executed from a restricted user (i.e not root).

This is explained by the pthread_setname_np() implementation [1].

If we try to rename the thread calling pthread_setname_np(), then
"prctl (PR_SET_NAME, name)" will be used and the new name will be accepted.

But if we try to rename another thread, the PROCFS will be used
(/proc/self/task/<pid>/comm) and for some reason "comm" can't be written by
the user.

Make sure to rename a thread by calling pthread_setname_np() from the thread
to be renamed.

[1] https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/pthread_setname.c;h=6c5e1d6e485eaffed227156b6ccd75e54cc34a03;hb=fdfc9260b61d3d72541f181$
