### PR TITLE
[FIX] increase the i210 link up timeout

### DIFF
--- a/stack/src/kernel/edrv/edrv-i210.c
+++ b/stack/src/kernel/edrv/edrv-i210.c
@@ -372,7 +372,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define EDRV_STATUS_DEV_RST_SET          (1 << 20)         // Device reset done
 #define EDRV_SW_RST_DONE_TIMEOUT         10   // ms        // Software rest timeout
 #define EDRV_MASTER_DIS_TIMEOUT          90   // ms        // Master disable timeout
-#define EDRV_LINK_UP_TIMEOUT             3000 // ms        // Link up timeout
+#define EDRV_LINK_UP_TIMEOUT             6000 // ms        // Link up timeout
 #define EDRV_AUTO_READ_DONE_TIMEOUT      10                // Auto register read done timeout
 #define EDRV_PHY_SEMPHORE_TIMEOUT        100
 #define EDRV_POLL_TIMEOUT                3                 // Tx-Rx Enable bit poll timeout


### PR DESCRIPTION
From time to time, the edrv i210 reach the link up timeout (3sec), thus the
openpowerlink stack fail to initialize correctly leading to the following
error:
oplk_create() with "Resource could not be created (Windows, PxROS, ...)" (0x0008)

By measuring the link up time, it appear that the nominal link up time is
"very" close to the timeout (~2.2sec to ~3.0+ sec).

Increase the timeout to 6sec in order to reach the timeout only if the
ethernet cable is really not connected.

Signed-off-by: Romain Naour <romain.naour@smile.fr>