### PR TITLE
[FIX] Solve dereferencing of a null pointer

### DIFF
--- a/stack/src/kernel/event/eventkcal-linuxkernel.c
+++ b/stack/src/kernel/event/eventkcal-linuxkernel.c
@@ -48,6 +48,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <oplk/debugstr.h>
 
 #include <linux/kthread.h>
+#include <linux/err.h>
 #include <linux/errno.h>
 #include <linux/wait.h>
 #include <linux/delay.h>
@@ -166,6 +167,12 @@ tOplkError eventkcal_init(void)
 
     instance_l.threadId = kthread_run(eventThread, NULL, "EventkThread");
 
+    if (IS_ERR(instance_l.threadId))
+    {
+        instance_l.threadId = NULL;
+        goto Exit;
+    }
+
     set_cpus_allowed_ptr(instance_l.threadId, cpumask_of(1));
 
     instance_l.fInitialized = TRUE;
@@ -202,7 +209,10 @@ tOplkError eventkcal_exit(void)
 
     instance_l.fInitialized = FALSE;
 
-    kthread_stop(instance_l.threadId);
+    if (instance_l.threadId)
+        kthread_stop(instance_l.threadId);
+
+    instance_l.threadId = NULL;
 
     while (instance_l.fThreadIsRunning)
     {


### PR DESCRIPTION
The task_struct pointer retruned by kthread_run() is not checked and
can lead to a kernel oops "kernel NULL pointer dereference" when
calling eventkcal_exit() if an error occured.

 PLK: + powerlinkOpen...
 PLK: + powerlinkOpen - OK
 BUG: unable to handle kernel NULL pointer dereference at 0000000c
 IP: [<c105b6e6>] kthread_stop+0x16/0x160
 *pde = 00000000
 Oops: 0002 [#1] PREEMPT SMP

 Call Trace:
  [<f812abff>] eventkcal_exit+0x1f/0x70 [oplki210mn]
  [<f812a61d>] eventk_exit+0xd/0x10 [oplki210mn]
  [<f8124b76>] shutdownStack+0x26/0x40 [oplki210mn]
  [<f8124cb5>] ctrlk_executeCmd+0xb5/0x250 [oplki210mn]
  [<c1107e8a>] ? pagefault_enable+0x1a/0x20
  [<f8124509>] powerlinkIoctl+0x149/0x2a0 [oplki210mn]
  [<c1079405>] ? rt_up_read+0x25/0x30
  [<f81243c0>] ? readInitParam+0x50/0x50 [oplki210mn]
  [<c1133d92>] do_vfs_ioctl+0x2d2/0x4b0
  [<c111f5fa>] ? filp_close+0x4a/0x70
  [<c1133fd8>] SyS_ioctl+0x68/0x80
  [<c153f54c>] sysenter_do_call+0x12/0x12

Fix this by checking the pointer returned by kthread_run() with
IS_ERR(treadId) and by checking it before calling kthread_stop().

Signed-off-by: Romain Naour romain.naour@smile.fr
