### PR TITLE
[FIX] Veth: Fix compilation on Linux kernels >= 4.7

### DIFF
--- a/stack/src/kernel/veth/veth-linuxkernel.c
+++ b/stack/src/kernel/veth/veth-linuxkernel.c
@@ -287,7 +287,11 @@ static int vethStartXmit(struct sk_buff* pSkb_p, struct net_device* pNetDevice_p
     struct net_device_stats* pStats = netdev_priv(pNetDevice_p);
 
     //save time stamp
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 7, 0))
     pNetDevice_p->trans_start = jiffies;
+#else
+    netif_trans_update(pNetDevice_p);
+#endif
 
     frameInfo.frame.pBuffer = (tPlkFrame*)pSkb_p->data;
     frameInfo.frameSize = pSkb_p->len;


### PR DESCRIPTION
dev->trans_start was replaced by netif_trans_update helper in kernel
4.7 by commit 860e9538a9482bb84589f7d0718a7e6d0a944d58.

Signed-off-by: Romain Naour <romain.naour@gmail.com>