### PR TITLE
resolve kernel panic on a RMN/CN device with hrtimer and preempt-rt

### DIFF
--- a/stack/include/kernel/edrvcyclic.h
+++ b/stack/include/kernel/edrvcyclic.h
@@ -106,7 +106,7 @@ extern "C"
 tOplkError edrvcyclic_init(void);
 tOplkError edrvcyclic_exit(void);
 tOplkError edrvcyclic_setCycleTime(UINT32 cycleTimeUs_p, UINT32 minSyncTime_p);
-tOplkError edrvcyclic_startCycle(void);
+tOplkError edrvcyclic_startCycle(BOOL fredudancy_p);
 tOplkError edrvcyclic_stopCycle(BOOL fKeepCycle_p);
 tOplkError edrvcyclic_setMaxTxBufferListSize(UINT maxListSize_p);
 tOplkError edrvcyclic_setNextTxBufferList(tEdrvTxBuffer** ppTxBuffer_p, UINT txBufferCount_p) SECTION_EDRVCYC_SET_NEXT_TX;

--- a/stack/src/kernel/dll/dllkevent.c
+++ b/stack/src/kernel/dll/dllkevent.c
@@ -500,6 +500,12 @@ static tOplkError processNmtStateChange(tNmtState newNmtState_p,
                 if ((ret = hrestimer_deleteTimer(&dllkInstance_g.timerHdlSwitchOver)) != kErrorOk)
                     return ret;
 
+                /* start cycle timer to send frames */
+                ret = edrvcyclic_startCycle(TRUE);
+                if(ret != kErrorOk) {
+                    return ret;
+                }
+
                 dllkInstance_g.socTime.relTime += dllkInstance_g.dllConfigParam.cycleLen;
                 // initialize SoAReq number for ProcessSync (cycle preparation)
                 dllkInstance_g.syncLastSoaReq = dllkInstance_g.curLastSoaReq;

--- a/stack/src/kernel/dll/dllkframe.c
+++ b/stack/src/kernel/dll/dllkframe.c
@@ -2164,7 +2164,7 @@ static tOplkError processReceivedSoc(tEdrvRxBuffer* pRxBuffer_p, tNmtState nmtSt
                                   dllkInstance_g.dllConfigParam.delayedSwitchOverTimeMn * 1000ULL,
                                   dllk_cbTimerSwitchOver, 0L, FALSE);
         }
-        if ((ret = edrvcyclic_startCycle()) != kErrorOk)
+        if ((ret = edrvcyclic_startCycle(FALSE)) != kErrorOk)
             return ret;
     }
     else

--- a/stack/src/kernel/dll/dllkstatemachine.c
+++ b/stack/src/kernel/dll/dllkstatemachine.c
@@ -360,7 +360,7 @@ static tOplkError processNmtMsFullCycle(tNmtState nmtState_p, tNmtEvent nmtEvent
                     if (ret != kErrorOk)
                         return ret;
 
-                    if ((ret = edrvcyclic_startCycle()) != kErrorOk)
+                    if ((ret = edrvcyclic_startCycle(TRUE)) != kErrorOk)
                         return ret;
 
                     // initialize cycle counter

--- a/stack/src/kernel/edrv/edrvcyclic.c
+++ b/stack/src/kernel/edrv/edrvcyclic.c
@@ -307,12 +307,15 @@ tOplkError edrvcyclic_setCycleTime(UINT32 cycleTimeUs_p, UINT32 minSyncTime_p)
 
 This function starts the cycles.
 
+\param  fredudancy_p    if TRUE, start cyclic timer,
+                        otherwise start one shot timer
+
 \return The function returns a tOplkError error code.
 
 \ingroup module_edrv
 */
 //------------------------------------------------------------------------------
-tOplkError edrvcyclic_startCycle(void)
+tOplkError edrvcyclic_startCycle(BOOL fredudancy_p)
 {
     tOplkError ret = kErrorOk;
 
@@ -330,7 +333,7 @@ tOplkError edrvcyclic_startCycle(void)
 
     ret = hrestimer_modifyTimer(&edrvcyclicInstance_l.timerHdlCycle,
                                 edrvcyclicInstance_l.cycleTimeUs * 1000ULL,
-                                timerHdlCycleCb, 0L, TRUE);
+                                timerHdlCycleCb, 0L, fredudancy_p);
 
 #if (EDRV_USE_TTTX == TRUE)
     edrvcyclicInstance_l.fNextCycleValid = FALSE;


### PR DESCRIPTION
Resolve kernel panic on a RMN/CN device when the stack restarts the cycle timer on SoC frame reception.

see [issue n°152](https://github.com/OpenAutomationTechnologies/openPOWERLINK_V2/issues/152) for further informations.