### PR TITLE
[FIX] Reduce timeout steps in ctrlucal_executeCmd for dualprocshm CAL

### DIFF
--- a/stack/src/arch/altera-c5socarm/sleep.c
+++ b/stack/src/arch/altera-c5socarm/sleep.c
@@ -222,7 +222,7 @@ static inline uint64_t getTimerTicksFromScaled(ALT_GPT_TIMER_t timerId_p,
                                                uint32_t scalingFactor_p,
                                                uint32_t scaledTimeDuration_p)
 {
-    uint64_t    ticks = 0;                      // value to return
+    uint64_t    ticks = 0;                          // value to return
     ALT_CLK_t   clkSrc = ALT_CLK_UNKNOWN;
     uint32_t    preScaler = 0;
     uint32_t    freq = 1;
@@ -247,7 +247,8 @@ static inline uint64_t getTimerTicksFromScaled(ALT_GPT_TIMER_t timerId_p,
             ticks *= freq;
 
             // total clock ticks
-            ticks *= (uint64_t)(scaledTimeDuration_p / scalingFactor_p);
+            ticks /= scalingFactor_p;               //TODO: Improve fixed point division
+            ticks *= (uint64_t)scaledTimeDuration_p;
 
             // convert into timer ticks
             ticks /= (preScaler + 1);

--- a/stack/src/user/ctrl/ctrlucal-noosdual.c
+++ b/stack/src/user/ctrl/ctrlucal-noosdual.c
@@ -59,8 +59,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //------------------------------------------------------------------------------
 // const defines
 //------------------------------------------------------------------------------
-#define CMD_TIMEOUT_SEC                 20      // command timeout in seconds
-#define DPSHM_ENABLE_TIMEOUT_SEC        10      // wait for dpshm interface enable time out
+#define CMD_TIMEOUT_SEC                 20          // command timeout in seconds
+#define CMD_TIMEOUT_LOOP_MSEC           10          // wait for dpshm interface enable time out
+#define CMD_TIMEOUT_LOOP_COUNT          (CMD_TIMEOUT_SEC * 1000U / CMD_TIMEOUT_LOOP_MSEC)     // loop count value
 
 //------------------------------------------------------------------------------
 // module global vars
@@ -138,7 +139,7 @@ tOplkError ctrlucal_init(void)
         return kErrorNoResource;
     }
 
-    for (loopCount = 0; loopCount <= DPSHM_ENABLE_TIMEOUT_SEC; loopCount++)
+    for (loopCount = 0; loopCount <= CMD_TIMEOUT_LOOP_MSEC; loopCount++)
     {
         target_msleep(1000U);
         dualRet = dualprocshm_checkShmIntfState(instance_l.dualProcDrvInst);
@@ -242,9 +243,9 @@ tOplkError ctrlucal_executeCmd(tCtrlCmdType cmd_p,
         return kErrorGeneralError;
 
     // wait for response
-    for (timeout = 0; timeout < CMD_TIMEOUT_SEC; timeout++)
+    for (timeout = 0; timeout < CMD_TIMEOUT_LOOP_COUNT; timeout++)
     {
-        target_msleep(1000U);
+        target_msleep(CMD_TIMEOUT_LOOP_MSEC);
 
         dualRet = dualprocshm_readDataCommon(instance_l.dualProcDrvInst,
                                              offsetof(tCtrlBuf, ctrlCmd),


### PR DESCRIPTION
This replaces pull #207  with incorporated review comments.

[FIX] Reduce timeout steps in ctrlucal_executeCmd for dualprocshm CAL
 - In the case of dualprocshm CAL, the function ctrlucal_executeCmd()
   posts a command and checks for a result periodically, before
   exiting because of a timeout.
 - The total clock tick value in sleep.c becomes zero for sleep times
   lesser than 1 second. To fix this, use fixed point division.
 - To reduce the granularity of the checks from 1 second to 10
   milliseconds in ctrlucal_executeCmd(), reduce the sleep time into
   10 milliseconds. This fix reduces the boot time in dual processor
   shared memory designs.

