### PR TITLE
Fix SKIP_BITSTREAM enable in Zynq Hybrid design

### DIFF
--- a/hardware/boards/xilinx-z702/mn-dual-shmem-gpio/vivado/system_bd.tcl
+++ b/hardware/boards/xilinx-z702/mn-dual-shmem-gpio/vivado/system_bd.tcl
@@ -48,7 +48,7 @@ if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
 
 # Create project
 set proj_name system
-create_project $proj_name system -part xc7z020clg484-1
+create_project -force $proj_name system -part xc7z020clg484-1
 
 # Set project properties
 set obj [get_projects $proj_name]

--- a/hardware/cmake/xilinx/genbitstream.cmake
+++ b/hardware/cmake/xilinx/genbitstream.cmake
@@ -2,7 +2,7 @@
 #
 # CMake macro for generating the bitstream for Microblaze Vivado
 #
-# Copyright (c) 2016, Kalycito Infotech Private Limited
+# Copyright (c) 2017, Kalycito Infotech Private Limited
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -38,7 +38,8 @@ MACRO(GENERATE_BITS EXAMPLE_NAME HW_DEMO_DIR SKIP_BITSTREAM)
 
         IF(SKIP_BITSTREAM)
             ADD_CUSTOM_COMMAND(
-                COMMAND ${XIL_VIVADO} -mode batch -source ${ARCH_TOOLS_DIR}/genbitvivado.tcl -tclargs ${VIVADO_DEMO_DIR}
+                OUTPUT ${VIVADO_DEMO_DIR}/system/system.runs/impl_1/system_wrapper_timing_summary_routed.rpt
+                COMMAND ${XIL_VIVADO} -mode batch -source ${ARCH_TOOLS_DIR}/gennobitvivado.tcl -tclargs ${VIVADO_DEMO_DIR}
                 WORKING_DIRECTORY ${VIVADO_DEMO_DIR}
             )
 
@@ -67,6 +68,8 @@ MACRO(GENERATE_BITS EXAMPLE_NAME HW_DEMO_DIR SKIP_BITSTREAM)
 
         # Add all generated files to clean target
         SET(ADD_CLEAN_FILES ${ADD_CLEAN_FILES}
+                            ${VIVADO_DEMO_DIR}/vivado.jou
+                            ${VIVADO_DEMO_DIR}/vivado.log
                             ${VIVADO_DEMO_DIR}/system
            )
     ELSE()

--- a/tools/xilinx-microblaze/gennobitvivado.tcl
+++ b/tools/xilinx-microblaze/gennobitvivado.tcl
@@ -1,0 +1,32 @@
+################################################################################
+#
+# Generate the bitstream for Zynq Vivado design
+#
+# Copyright (c) 2017, Kalycito Infotech Private Limited
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the copyright holders nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+################################################################################
+
+#To avoid hardware recompilation
+exit;


### PR DESCRIPTION
This Pull request resolves the bitstream generation fail for enabling SKIP_BITSTREAM.

This resolves #173