### PR TITLE
[FIX] Data freshness issue on Zynq Hybrid design

### DIFF
--- a/drivers/linux/drv_kernelmod_zynq/main.c
+++ b/drivers/linux/drv_kernelmod_zynq/main.c
@@ -661,6 +661,8 @@ static int plkIntfMmap(struct file* pFile_p,
     pVmArea_p->vm_pgoff = (ULONG)pageAddr >> PAGE_SHIFT;
     // Save the offset of the mapped memory address from the start of page boundary
     instance_l.bufPageOffset = ((ULONG)pageAddr - (pVmArea_p->vm_pgoff << PAGE_SHIFT));
+    // Disabled cache of the mapped memory address
+    pVmArea_p->vm_page_prot = pgprot_noncached(pVmArea_p->vm_page_prot);
 
     if (io_remap_pfn_range(pVmArea_p,
                            pVmArea_p->vm_start,


### PR DESCRIPTION
 - Disabled cache for PDO data memory mapping on ARM Linux.

 - Resolves bug #218.

Known issues with this pull request:
1) MN gets stopped when non POWERLINK frame packets are received indicating cycle time exceed error(0x8232)