### PR TITLE
[FIX] Solve data freshness issue on Zynq Hybrid design

### DIFF
--- a/drivers/linux/drv_kernelmod_zynq/main.c
+++ b/drivers/linux/drv_kernelmod_zynq/main.c
@@ -12,7 +12,7 @@ for the openPOWERLINK kernel stack.
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
-Copyright (c) 2016, Kalycito Private Limited
+Copyright (c) 2017, Kalycito Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -661,6 +661,8 @@ static int plkIntfMmap(struct file* pFile_p,
     pVmArea_p->vm_pgoff = (ULONG)pageAddr >> PAGE_SHIFT;
     // Save the offset of the mapped memory address from the start of page boundary
     instance_l.bufPageOffset = ((ULONG)pageAddr - (pVmArea_p->vm_pgoff << PAGE_SHIFT));
+    // Disable cache of the mapped memory address
+    pVmArea_p->vm_page_prot = pgprot_noncached(pVmArea_p->vm_page_prot);
 
     if (io_remap_pfn_range(pVmArea_p,
                            pVmArea_p->vm_start,


### PR DESCRIPTION
 - Disable cache for device memory mapping.

This pull request updates the review comments for the pull request #220