### PR TITLE
Properly shutdown pcap thread using pthread_cancel()

### DIFF
--- a/stack/src/kernel/edrv/edrv-pcap_linux.c
+++ b/stack/src/kernel/edrv/edrv-pcap_linux.c
@@ -225,6 +225,7 @@ tOplkError edrv_exit(void)
 {
     // End the pcap loop and wait for the worker thread to terminate
     pcap_breakloop(edrvInstance_l.pPcapThread);
+    pthread_cancel(edrvInstance_l.hThread);
     pthread_join(edrvInstance_l.hThread, NULL);
 
     // Close pcap instance
@@ -566,8 +567,11 @@ static void* workerThread(void* pArgument_p)
 {
     tEdrvInstance*  pInstance = (tEdrvInstance*)pArgument_p;
     int             pcapRet;
+    int             oldCancelType;
 
     DEBUG_LVL_EDRV_TRACE("%s(): ThreadId:%ld\n", __func__, syscall(SYS_gettid));
+
+    pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, &oldCancelType);
 
     // Set up and activate the pcap live capture handle
     pInstance->pPcapThread = startPcap();


### PR DESCRIPTION
On my dev system, when terminating the managing node via Ctrl+C, the managing node was stuck in pcap_loop(). The shutdown-thread does call pcap_break(), however according to the libpcap-documentation this is not enough to terminate another thread (it simply sets a flag):

> Note also that, in a multi-threaded application, if one thread is blocked in pcap_dispatch(), pcap_loop(), pcap_next(), or pcap_next_ex(), a call to pcap_breakloop() in a different thread will not unblock that thread; you will need to use whatever mechanism the OS provides for breaking a thread out of blocking calls in order to unblock the thread, such as thread cancellation in systems that support POSIX threads.

This patch sets the canability of the pcap-thread and calls pthread_cancel when shutting down. On systems where pthread_cancel is not supported, it doesn't change the behaviour.