### PR TITLE
[FIX] Resolve compilation issue in Zynq hybrid design

### DIFF
--- a/cmake/microblazeapppostactions.cmake
+++ b/cmake/microblazeapppostactions.cmake
@@ -46,6 +46,7 @@ ADD_CUSTOM_COMMAND(
     POST_BUILD
     COMMAND mb-size ${EXECUTABLE_NAME} | tee "${PROJECT_NAME}.size"
     COMMAND arm-xilinx-eabi-objcopy -I elf32-little -O elf32-little -R .local_memory -R .vectors.* ${EXECUTABLE_NAME} ${PROJECT_BINARY_DIR}/oplkdrv_daemon_o.elf
+    COMMAND make create-bit
 )
 
 SET_DIRECTORY_PROPERTIES(PROPERTIES


### PR DESCRIPTION
This pull request avoids the "make create-bit" step to independently build HW.

The first time build is to be done with SKIP_BITSTREAM disabled even if there is no changes to the HW. Subsequent SW only changes can be built with SKIP_BITSTREAM enabled.