### PR TITLE
Avoid integer overflow in searchIndex by exiting early in case numEnt…

### DIFF
--- a/stack/src/user/obd/obdu.c
+++ b/stack/src/user/obd/obdu.c
@@ -2369,6 +2369,9 @@ static tObdEntry* searchIndex(const tObdEntry* pObdEntry_p,
     UINT32  last;
     UINT32  middle;
 
+    if (numEntries_p == 0)
+        return NULL;
+
     first = 0;
     last = numEntries_p - 1;
 


### PR DESCRIPTION
When searchIndex is called with numEntries=0, an integer overflow happens for the "last" variable resulting typically in a segmentation fault whil iterating over indexes that do not exist. This can happen when e.g. accessig a non-existent variable in the manufacturer-part in the obd, when the manufacturer-specicif part of the ODB has 0 entries.

By exiting early in this case (there is nothing to be found anyway) this crash can be avoided without introducing any more complex control flow to the actual search loop.