### PR TITLE
[FEATURE] Add SoC time stamp forwarding feature in BSD semaphore design

### DIFF
--- a/stack/include/common/timesync.h
+++ b/stack/include/common/timesync.h
@@ -8,6 +8,7 @@
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -44,6 +45,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // const defines
 //------------------------------------------------------------------------------
 #define TIMESYNC_SYNC_BSDSEM            "/semTimeSyncSync"
+#define TIMESYNC_TIMESTAMP_SHM          "/shmTimeSyncTimestamp"
 
 //------------------------------------------------------------------------------
 // typedef


### PR DESCRIPTION
 - Create a shared memory between kernel and user layer to store SoC
   timestamps using mmap.
 - The initialized shared memory is unmapped during the exit of the
   function.

This pull request also takes care of the comments from the previous pull request #227