### PR TITLE
make c5socarm project compatible with quartus16.1

### DIFF
--- a/apps/common/src/system/system-c5socarm.c
+++ b/apps/common/src/system/system-c5socarm.c
@@ -373,7 +373,7 @@ static int initializeTimer(void)
     // set the comparator value to the maximum global timer value even though we do not use it
     // the 'alt_gpt_curtime_millisecs_get()' api uses this to determine current time
     if ((alt_globaltmr_autoinc_set(1) != ALT_E_SUCCESS) ||
-        (alt_globaltmr_comp_set64(GLOBALTMR_MAX) != ALT_E_SUCCESS))
+        (alt_globaltmr_comp_set64(ALT_GLOBALTMR_MAX) != ALT_E_SUCCESS))
     {
         TRACE("Auto increment mode could not be enabled for this timer!\n");
     }

--- a/apps/demo_mn_embedded/c5socarm.cmake
+++ b/apps/demo_mn_embedded/c5socarm.cmake
@@ -131,7 +131,7 @@ INCLUDE_DIRECTORIES(
 ################################################################################
 # Set architecture specific definitions
 SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${ALT_HOST_CFLAGS} -std=c99")
-ADD_DEFINITIONS(-D__ALTERA_ARM__)
+ADD_DEFINITIONS(-D__ALTERA_ARM__ -Dsoc_cv_av)
 
 ################################################################################
 # Set architecture specific linker flags

--- a/contrib/dualprocshm/cmake/configure-c5socarm.cmake
+++ b/contrib/dualprocshm/cmake/configure-c5socarm.cmake
@@ -45,7 +45,7 @@ SET(LIB_ARCH_INCS
 # Set architecture specific definitions
 
 SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${ALT_${PROC_INST_NAME}_FLAGS} -fmessage-length=0 -mcpu=${CFG_${PROC_INST_NAME}_CPU_VERSION} -ffunction-sections -fdata-sections -fno-inline")
-ADD_DEFINITIONS(-D__C5SOC__ -D__ALTERA_ARM__)
+ADD_DEFINITIONS(-D__C5SOC__ -D__ALTERA_ARM__ -Dsoc_cv_av)
 
 ################################################################################
 # Set architecture specific installation files

--- a/hardware/boards/altera-c5soc/mn-soc-shmem-gpio/cmake/configure-hal.cmake
+++ b/hardware/boards/altera-c5soc/mn-soc-shmem-gpio/cmake/configure-hal.cmake
@@ -36,21 +36,21 @@
 UNSET(LIB_HOST_ARCH_HAL_SRCS)
 SET(LIB_HOST_ARCH_HAL_SRCS
             src/hwmgr/alt_address_space.c
-            src/hwmgr/alt_bridge_manager.c
+            src/hwmgr/soc_cv_av/alt_bridge_manager.c
             src/hwmgr/alt_cache.c
-            src/hwmgr/alt_clock_manager.c
+            src/hwmgr/soc_cv_av/alt_clock_manager.c
             src/hwmgr/alt_dma_program.c
             src/hwmgr/alt_dma.c
 
-            src/hwmgr/alt_fpga_manager.c
+            src/hwmgr/soc_cv_av/alt_fpga_manager.c
             src/hwmgr/alt_generalpurpose_io.c
             src/hwmgr/alt_globaltmr.c
             src/hwmgr/alt_i2c.c
             src/hwmgr/alt_interrupt.c
             src/hwmgr/alt_mmu.c
 
-            src/hwmgr/alt_reset_manager.c
-            src/hwmgr/alt_system_manager.c
+            src/hwmgr/soc_cv_av/alt_reset_manager.c
+            src/hwmgr/soc_cv_av/alt_system_manager.c
             src/hwmgr/alt_timers.c
             src/hwmgr/alt_watchdog.c
     )
@@ -58,9 +58,10 @@ SET(LIB_HOST_ARCH_HAL_SRCS
 UNSET(LIB_HOST_ARCH_HAL_INCS)
 SET(LIB_HOST_ARCH_HAL_INCS
             ${HOST_HWLIB_PATH}/include
+            ${HOST_HWLIB_PATH}/include/soc_cv_av
     )
 
 UNSET(LIB_HOST_ARCH_HAL_C_FLAGS)
-SET(LIB_HOST_ARCH_HAL_C_FLAGS "-D__ALTERA_ARM__  -O3 -Ofast -g -Wall -std=c99 " )
+SET(LIB_HOST_ARCH_HAL_C_FLAGS "-D__ALTERA_ARM__ -Dsoc_cv_av -O3 -Ofast -g -Wall -std=c99 " )
 UNSET(ARCH_HOST_MODULE_NAME)
 SET(ARCH_HOST_MODULE_NAME    ${CFG_HOST_NAME}_arm_a9_0)

--- a/hardware/boards/altera-c5soc/mn-soc-shmem-gpio/quartus/mnSocShmemGpio.qsys
+++ b/hardware/boards/altera-c5soc/mn-soc-shmem-gpio/quartus/mnSocShmemGpio.qsys
@@ -7,11 +7,8 @@
    description=""
    tags=""
    categories="System" />
- <parameter name="bonusData"><![CDATA[bonusData
+ <parameter name="bonusData"><![CDATA[bonusData 
 {
-   element $${FILENAME}
-   {
-   }
    element address_span_extender_cpu_bridge
    {
       datum _sortIndex
@@ -67,11 +64,19 @@
          type = "boolean";
       }
    }
-   element sysid_qsys.control_slave
+   element com_mem.s1
    {
       datum baseAddress
       {
-         value = "27136";
+         value = "0";
+         type = "String";
+      }
+   }
+   element com_mem.s2
+   {
+      datum baseAddress
+      {
+         value = "28672";
          type = "String";
       }
    }
@@ -101,14 +106,6 @@
          type = "boolean";
       }
    }
-   element openmac_0.macTimer
-   {
-      datum baseAddress
-      {
-         value = "26624";
-         type = "String";
-      }
-   }
    element openmac_0
    {
       datum _sortIndex
@@ -120,6 +117,14 @@
       {
          value = "1";
          type = "boolean";
+      }
+   }
+   element openmac_0.macTimer
+   {
+      datum baseAddress
+      {
+         value = "26624";
+         type = "String";
       }
    }
    element pcp_0
@@ -135,22 +140,6 @@
          type = "boolean";
       }
    }
-   element com_mem.s1
-   {
-      datum baseAddress
-      {
-         value = "0";
-         type = "String";
-      }
-   }
-   element com_mem.s2
-   {
-      datum baseAddress
-      {
-         value = "28672";
-         type = "String";
-      }
-   }
    element sysid_qsys
    {
       datum _sortIndex
@@ -162,6 +151,14 @@
       {
          value = "1";
          type = "boolean";
+      }
+   }
+   element sysid_qsys.control_slave
+   {
+      datum baseAddress
+      {
+         value = "27136";
+         type = "String";
       }
    }
 }
@@ -176,6 +173,7 @@
  <parameter name="globalResetBus" value="false" />
  <parameter name="hdlLanguage" value="VERILOG" />
  <parameter name="hideFromIPCatalog" value="false" />
+ <parameter name="lockedInterfaceDefinition" value="" />
  <parameter name="maxAdditionalLatency" value="1" />
  <parameter name="projectName">mn-soc-shmem-gpio.qpf</parameter>
  <parameter name="sopcBorderPoints" value="false" />
@@ -185,17 +183,26 @@
  <parameter name="useTestBenchNamingPattern" value="false" />
  <instanceScript></instanceScript>
  <interface
-   name="memory_fpga"
-   internal="ddr3_emif_0.memory"
+   name="button_pio_external_connection"
+   internal="host_0.button_pio_external_connection"
    type="conduit"
    dir="end" />
- <interface name="oct" internal="ddr3_emif_0.oct" type="conduit" dir="end" />
+ <interface name="clk_100" internal="clk_100.clk_in" type="clock" dir="end" />
  <interface name="clk_50" internal="clk_50.clk_in" type="clock" dir="end" />
- <interface name="reset" internal="clk_50.clk_in_reset" type="reset" dir="end" />
  <interface
-   name="ddr3_emif_0_status"
-   internal="ddr3_emif_0.status"
-   type="conduit"
+   name="ddr3_emif_0_afi_reset_export"
+   internal="ddr3_emif_0.afi_reset_export"
+   type="reset"
+   dir="start" />
+ <interface
+   name="ddr3_emif_0_global_reset"
+   internal="ddr3_emif_0.global_reset"
+   type="reset"
+   dir="end" />
+ <interface
+   name="ddr3_emif_0_pll_ref_clk"
+   internal="ddr3_emif_0.pll_ref_clk"
+   type="clock"
    dir="end" />
  <interface
    name="ddr3_emif_0_pll_sharing"
@@ -203,29 +210,13 @@
    type="conduit"
    dir="end" />
  <interface
-   name="ddr3_emif_0_global_reset"
-   internal="ddr3_emif_0.global_reset"
-   type="reset"
-   dir="end" />
- <interface
-   name="ddr3_emif_0_afi_reset_export"
-   internal="ddr3_emif_0.afi_reset_export"
-   type="reset"
-   dir="start" />
- <interface
    name="ddr3_emif_0_soft_reset"
    internal="ddr3_emif_0.soft_reset"
    type="reset"
    dir="end" />
- <interface name="clk_100" internal="clk_100.clk_in" type="clock" dir="end" />
  <interface
-   name="ddr3_emif_0_pll_ref_clk"
-   internal="ddr3_emif_0.pll_ref_clk"
-   type="clock"
-   dir="end" />
- <interface
-   name="powerlink_led"
-   internal="pcp_0.powerlink_led"
+   name="ddr3_emif_0_status"
+   internal="ddr3_emif_0.status"
    type="conduit"
    dir="end" />
  <interface
@@ -234,23 +225,16 @@
    type="conduit"
    dir="end" />
  <interface
-   name="button_pio_external_connection"
-   internal="host_0.button_pio_external_connection"
+   name="host_0_hps_0_h2f_cold_reset"
+   internal="host_0.hps_0_h2f_cold_reset"
+   type="reset"
+   dir="start" />
+ <interface
+   name="host_0_hps_0_h2f_gp"
+   internal="host_0.hps_0_h2f_gp"
    type="conduit"
    dir="end" />
- <interface name="memory" internal="host_0.memory" type="conduit" dir="end" />
- <interface name="hps_io" internal="host_0.hps_0_hps_io" type="conduit" dir="end" />
  <interface name="host_0_hps_0_h2f_reset" internal="host_0.hps_0_h2f_reset" />
- <interface
-   name="openmac_0_mii"
-   internal="openmac_0.mii"
-   type="conduit"
-   dir="end" />
- <interface
-   name="openmac_0_smi"
-   internal="openmac_0.smi"
-   type="conduit"
-   dir="end" />
  <interface
    name="hps_0_f2h_cold_reset_req"
    internal="host_0.hps_0_f2h_cold_reset_req"
@@ -266,22 +250,22 @@
    internal="host_0.hps_0_f2h_warm_reset_req"
    type="reset"
    dir="end" />
+ <interface name="hps_io" internal="host_0.hps_0_hps_io" type="conduit" dir="end" />
+ <interface name="memory" internal="host_0.memory" type="conduit" dir="end" />
  <interface
-   name="host_0_hps_0_h2f_gp"
-   internal="host_0.hps_0_h2f_gp"
+   name="memory_fpga"
+   internal="ddr3_emif_0.memory"
+   type="conduit"
+   dir="end" />
+ <interface name="oct" internal="ddr3_emif_0.oct" type="conduit" dir="end" />
+ <interface
+   name="openmac_0_mii"
+   internal="openmac_0.mii"
    type="conduit"
    dir="end" />
  <interface
-   name="host_0_hps_0_h2f_cold_reset"
-   internal="host_0.hps_0_h2f_cold_reset"
-   type="reset"
-   dir="start" />
- <interface
-   name="pcp_cpu_0_cpu_resetrequest"
-   internal="pcp_0.cpu_0_cpu_resetrequest" />
- <interface
-   name="pcp_0_cpu_resetrequest"
-   internal="pcp_0.cpu_resetrequest"
+   name="openmac_0_smi"
+   internal="openmac_0.smi"
    type="conduit"
    dir="end" />
  <interface
@@ -289,406 +273,84 @@
    internal="pcp_0.benchmark_pio_external_connection"
    type="conduit"
    dir="end" />
+ <interface
+   name="pcp_0_cpu_resetrequest"
+   internal="pcp_0.cpu_resetrequest"
+   type="conduit"
+   dir="end" />
+ <interface
+   name="pcp_cpu_0_cpu_resetrequest"
+   internal="pcp_0.cpu_0_cpu_resetrequest" />
+ <interface
+   name="powerlink_led"
+   internal="pcp_0.powerlink_led"
+   type="conduit"
+   dir="end" />
+ <interface name="reset" internal="clk_50.clk_in_reset" type="reset" dir="end" />
  <module
-   kind="altera_mem_if_ddr3_emif"
+   name="address_span_extender_cpu_bridge"
+   kind="altera_address_span_extender"
+   version="16.1"
+   enabled="1">
+  <parameter name="BURSTCOUNT_WIDTH" value="1" />
+  <parameter name="DATA_WIDTH" value="32" />
+  <parameter name="ENABLE_SLAVE_PORT" value="true" />
+  <parameter name="MASTER_ADDRESS_DEF" value="0" />
+  <parameter name="MASTER_ADDRESS_WIDTH" value="27" />
+  <parameter name="MAX_PENDING_READS" value="1" />
+  <parameter name="SLAVE_ADDRESS_WIDTH" value="20" />
+  <parameter name="SUB_WINDOW_COUNT" value="1" />
+ </module>
+ <module
+   name="address_span_extender_flash_bridge"
+   kind="altera_address_span_extender"
    version="14.0"
-   enabled="1"
-   name="ddr3_emif_0">
-  <parameter name="MEM_VENDOR" value="Micron" />
-  <parameter name="MEM_FORMAT" value="DISCRETE" />
-  <parameter name="RDIMM_CONFIG" value="0000000000000000" />
-  <parameter name="LRDIMM_EXTENDED_CONFIG">0x000000000000000000</parameter>
-  <parameter name="DISCRETE_FLY_BY" value="true" />
-  <parameter name="DEVICE_DEPTH" value="1" />
-  <parameter name="DEVICE_WIDTH" value="1" />
-  <parameter name="MEM_MIRROR_ADDRESSING" value="0" />
-  <parameter name="MEM_CLK_FREQ_MAX" value="800.0" />
-  <parameter name="MEM_ROW_ADDR_WIDTH" value="12" />
-  <parameter name="MEM_COL_ADDR_WIDTH" value="10" />
-  <parameter name="MEM_DQ_WIDTH" value="32" />
-  <parameter name="MEM_DQ_PER_DQS" value="8" />
-  <parameter name="MEM_BANKADDR_WIDTH" value="3" />
-  <parameter name="MEM_IF_DM_PINS_EN" value="true" />
-  <parameter name="MEM_IF_DQSN_EN" value="true" />
-  <parameter name="MEM_NUMBER_OF_DIMMS" value="1" />
-  <parameter name="MEM_NUMBER_OF_RANKS_PER_DIMM" value="1" />
-  <parameter name="MEM_NUMBER_OF_RANKS_PER_DEVICE" value="1" />
-  <parameter name="MEM_RANK_MULTIPLICATION_FACTOR" value="1" />
-  <parameter name="MEM_CK_WIDTH" value="1" />
-  <parameter name="MEM_CS_WIDTH" value="1" />
-  <parameter name="MEM_CLK_EN_WIDTH" value="1" />
-  <parameter name="ALTMEMPHY_COMPATIBLE_MODE" value="false" />
-  <parameter name="NEXTGEN" value="true" />
-  <parameter name="MEM_IF_BOARD_BASE_DELAY" value="10" />
-  <parameter name="MEM_IF_SIM_VALID_WINDOW" value="0" />
-  <parameter name="MEM_GUARANTEED_WRITE_INIT" value="false" />
-  <parameter name="MEM_VERBOSE" value="true" />
-  <parameter name="PINGPONGPHY_EN" value="false" />
-  <parameter name="DUPLICATE_AC" value="false" />
-  <parameter name="REFRESH_BURST_VALIDATION" value="false" />
-  <parameter name="MEM_BL" value="OTF" />
-  <parameter name="MEM_BT" value="Sequential" />
-  <parameter name="MEM_ASR" value="Manual" />
-  <parameter name="MEM_SRT" value="Normal" />
-  <parameter name="MEM_PD" value="DLL off" />
-  <parameter name="MEM_DRV_STR" value="RZQ/6" />
-  <parameter name="MEM_DLL_EN" value="true" />
-  <parameter name="MEM_RTT_NOM" value="ODT Disabled" />
-  <parameter name="MEM_RTT_WR" value="Dynamic ODT off" />
-  <parameter name="MEM_WTCL" value="5" />
-  <parameter name="MEM_ATCL" value="Disabled" />
-  <parameter name="MEM_TCL" value="6" />
-  <parameter name="MEM_AUTO_LEVELING_MODE" value="true" />
-  <parameter name="MEM_USER_LEVELING_MODE" value="Leveling" />
-  <parameter name="MEM_INIT_EN" value="false" />
-  <parameter name="MEM_INIT_FILE" value="" />
-  <parameter name="DAT_DATA_WIDTH" value="32" />
-  <parameter name="TIMING_TIS" value="170" />
-  <parameter name="TIMING_TIH" value="120" />
-  <parameter name="TIMING_TDS" value="10" />
-  <parameter name="TIMING_TDH" value="45" />
-  <parameter name="TIMING_TDQSQ" value="100" />
-  <parameter name="TIMING_TQH" value="0.38" />
-  <parameter name="TIMING_TDQSCK" value="255" />
-  <parameter name="TIMING_TDQSCKDS" value="450" />
-  <parameter name="TIMING_TDQSCKDM" value="900" />
-  <parameter name="TIMING_TDQSCKDL" value="1200" />
-  <parameter name="TIMING_TDQSS" value="0.27" />
-  <parameter name="TIMING_TQSH" value="0.4" />
-  <parameter name="TIMING_TDSH" value="0.18" />
-  <parameter name="TIMING_TDSS" value="0.18" />
-  <parameter name="MEM_TINIT_US" value="500" />
-  <parameter name="MEM_TMRD_CK" value="4" />
-  <parameter name="MEM_TRAS_NS" value="35.0" />
-  <parameter name="MEM_TRCD_NS" value="13.75" />
-  <parameter name="MEM_TRP_NS" value="13.75" />
-  <parameter name="MEM_TREFI_US" value="7.8" />
-  <parameter name="MEM_TRFC_NS" value="260.0" />
-  <parameter name="CFG_TCCD_NS" value="2.5" />
-  <parameter name="MEM_TWR_NS" value="15.0" />
-  <parameter name="MEM_TWTR" value="4" />
-  <parameter name="MEM_TFAW_NS" value="40.0" />
-  <parameter name="MEM_TRRD_NS" value="13.5" />
-  <parameter name="MEM_TRTP_NS" value="13.5" />
-  <parameter name="RATE" value="Full" />
-  <parameter name="MEM_CLK_FREQ" value="300.0" />
-  <parameter name="USE_MEM_CLK_FREQ" value="false" />
-  <parameter name="FORCE_DQS_TRACKING" value="AUTO" />
-  <parameter name="FORCE_SHADOW_REGS" value="AUTO" />
-  <parameter name="MRS_MIRROR_PING_PONG_ATSO" value="false" />
-  <parameter name="SYS_INFO_DEVICE_FAMILY" value="Cyclone V" />
-  <parameter name="PARSE_FRIENDLY_DEVICE_FAMILY_PARAM_VALID" value="false" />
-  <parameter name="PARSE_FRIENDLY_DEVICE_FAMILY_PARAM" value="" />
-  <parameter name="DEVICE_FAMILY_PARAM" value="" />
-  <parameter name="SPEED_GRADE" value="8" />
-  <parameter name="IS_ES_DEVICE" value="false" />
-  <parameter name="DISABLE_CHILD_MESSAGING" value="false" />
-  <parameter name="HARD_EMIF" value="true" />
-  <parameter name="HHP_HPS" value="false" />
-  <parameter name="HHP_HPS_VERIFICATION" value="false" />
-  <parameter name="HHP_HPS_SIMULATION" value="false" />
-  <parameter name="HPS_PROTOCOL" value="DEFAULT" />
-  <parameter name="CUT_NEW_FAMILY_TIMING" value="true" />
-  <parameter name="POWER_OF_TWO_BUS" value="false" />
-  <parameter name="SOPC_COMPAT_RESET" value="false" />
-  <parameter name="AVL_MAX_SIZE" value="1" />
-  <parameter name="BYTE_ENABLE" value="true" />
-  <parameter name="ENABLE_CTRL_AVALON_INTERFACE" value="true" />
-  <parameter name="CTL_DEEP_POWERDN_EN" value="false" />
-  <parameter name="CTL_SELF_REFRESH_EN" value="false" />
-  <parameter name="AUTO_POWERDN_EN" value="false" />
-  <parameter name="AUTO_PD_CYCLES" value="0" />
-  <parameter name="CTL_USR_REFRESH_EN" value="false" />
-  <parameter name="CTL_AUTOPCH_EN" value="false" />
-  <parameter name="CTL_ZQCAL_EN" value="false" />
-  <parameter name="ADDR_ORDER" value="2" />
-  <parameter name="CTL_LOOK_AHEAD_DEPTH" value="4" />
-  <parameter name="CONTROLLER_LATENCY" value="5" />
-  <parameter name="CFG_REORDER_DATA" value="true" />
-  <parameter name="STARVE_LIMIT" value="10" />
-  <parameter name="CTL_CSR_ENABLED" value="false" />
-  <parameter name="CTL_CSR_CONNECTION" value="INTERNAL_JTAG" />
-  <parameter name="CTL_ECC_ENABLED" value="false" />
-  <parameter name="CTL_HRB_ENABLED" value="false" />
-  <parameter name="CTL_ECC_AUTO_CORRECTION_ENABLED" value="false" />
-  <parameter name="MULTICAST_EN" value="false" />
-  <parameter name="CTL_DYNAMIC_BANK_ALLOCATION" value="false" />
-  <parameter name="CTL_DYNAMIC_BANK_NUM" value="4" />
-  <parameter name="DEBUG_MODE" value="false" />
-  <parameter name="ENABLE_BURST_MERGE" value="false" />
-  <parameter name="CTL_ENABLE_BURST_INTERRUPT" value="false" />
-  <parameter name="CTL_ENABLE_BURST_TERMINATE" value="false" />
-  <parameter name="LOCAL_ID_WIDTH" value="8" />
-  <parameter name="WRBUFFER_ADDR_WIDTH" value="6" />
-  <parameter name="MAX_PENDING_WR_CMD" value="8" />
-  <parameter name="MAX_PENDING_RD_CMD" value="16" />
-  <parameter name="USE_MM_ADAPTOR" value="true" />
-  <parameter name="USE_AXI_ADAPTOR" value="false" />
-  <parameter name="HCX_COMPAT_MODE" value="false" />
-  <parameter name="CTL_CMD_QUEUE_DEPTH" value="8" />
-  <parameter name="CTL_CSR_READ_ONLY" value="1" />
-  <parameter name="CFG_DATA_REORDERING_TYPE" value="INTER_BANK" />
-  <parameter name="NUM_OF_PORTS" value="1" />
-  <parameter name="ENABLE_BONDING" value="false" />
-  <parameter name="ENABLE_USER_ECC" value="false" />
-  <parameter name="AVL_DATA_WIDTH_PORT" value="32,32,32,32,32,32" />
-  <parameter name="PRIORITY_PORT" value="1,1,1,1,1,1" />
-  <parameter name="WEIGHT_PORT" value="0,0,0,0,0,0" />
-  <parameter name="CPORT_TYPE_PORT">Bidirectional,Bidirectional,Bidirectional,Bidirectional,Bidirectional,Bidirectional</parameter>
-  <parameter name="ENABLE_EMIT_BFM_MASTER" value="false" />
-  <parameter name="FORCE_SEQUENCER_TCL_DEBUG_MODE" value="false" />
-  <parameter name="ENABLE_SEQUENCER_MARGINING_ON_BY_DEFAULT" value="false" />
-  <parameter name="REF_CLK_FREQ" value="50.0" />
-  <parameter name="REF_CLK_FREQ_PARAM_VALID" value="false" />
-  <parameter name="REF_CLK_FREQ_MIN_PARAM" value="0.0" />
-  <parameter name="REF_CLK_FREQ_MAX_PARAM" value="0.0" />
-  <parameter name="PLL_DR_CLK_FREQ_PARAM" value="0.0" />
-  <parameter name="PLL_DR_CLK_FREQ_SIM_STR_PARAM" value="" />
-  <parameter name="PLL_DR_CLK_PHASE_PS_PARAM" value="0" />
-  <parameter name="PLL_DR_CLK_PHASE_PS_SIM_STR_PARAM" value="" />
-  <parameter name="PLL_DR_CLK_MULT_PARAM" value="0" />
-  <parameter name="PLL_DR_CLK_DIV_PARAM" value="0" />
-  <parameter name="PLL_MEM_CLK_FREQ_PARAM" value="0.0" />
-  <parameter name="PLL_MEM_CLK_FREQ_SIM_STR_PARAM" value="" />
-  <parameter name="PLL_MEM_CLK_PHASE_PS_PARAM" value="0" />
-  <parameter name="PLL_MEM_CLK_PHASE_PS_SIM_STR_PARAM" value="" />
-  <parameter name="PLL_MEM_CLK_MULT_PARAM" value="0" />
-  <parameter name="PLL_MEM_CLK_DIV_PARAM" value="0" />
-  <parameter name="PLL_AFI_CLK_FREQ_PARAM" value="0.0" />
-  <parameter name="PLL_AFI_CLK_FREQ_SIM_STR_PARAM" value="" />
-  <parameter name="PLL_AFI_CLK_PHASE_PS_PARAM" value="0" />
-  <parameter name="PLL_AFI_CLK_PHASE_PS_SIM_STR_PARAM" value="" />
-  <parameter name="PLL_AFI_CLK_MULT_PARAM" value="0" />
-  <parameter name="PLL_AFI_CLK_DIV_PARAM" value="0" />
-  <parameter name="PLL_WRITE_CLK_FREQ_PARAM" value="0.0" />
-  <parameter name="PLL_WRITE_CLK_FREQ_SIM_STR_PARAM" value="" />
-  <parameter name="PLL_WRITE_CLK_PHASE_PS_PARAM" value="0" />
-  <parameter name="PLL_WRITE_CLK_PHASE_PS_SIM_STR_PARAM" value="" />
-  <parameter name="PLL_WRITE_CLK_MULT_PARAM" value="0" />
-  <parameter name="PLL_WRITE_CLK_DIV_PARAM" value="0" />
-  <parameter name="PLL_ADDR_CMD_CLK_FREQ_PARAM" value="0.0" />
-  <parameter name="PLL_ADDR_CMD_CLK_FREQ_SIM_STR_PARAM" value="" />
-  <parameter name="PLL_ADDR_CMD_CLK_PHASE_PS_PARAM" value="0" />
-  <parameter name="PLL_ADDR_CMD_CLK_PHASE_PS_SIM_STR_PARAM" value="" />
-  <parameter name="PLL_ADDR_CMD_CLK_MULT_PARAM" value="0" />
-  <parameter name="PLL_ADDR_CMD_CLK_DIV_PARAM" value="0" />
-  <parameter name="PLL_AFI_HALF_CLK_FREQ_PARAM" value="0.0" />
-  <parameter name="PLL_AFI_HALF_CLK_FREQ_SIM_STR_PARAM" value="" />
-  <parameter name="PLL_AFI_HALF_CLK_PHASE_PS_PARAM" value="0" />
-  <parameter name="PLL_AFI_HALF_CLK_PHASE_PS_SIM_STR_PARAM" value="" />
-  <parameter name="PLL_AFI_HALF_CLK_MULT_PARAM" value="0" />
-  <parameter name="PLL_AFI_HALF_CLK_DIV_PARAM" value="0" />
-  <parameter name="PLL_NIOS_CLK_FREQ_PARAM" value="0.0" />
-  <parameter name="PLL_NIOS_CLK_FREQ_SIM_STR_PARAM" value="" />
-  <parameter name="PLL_NIOS_CLK_PHASE_PS_PARAM" value="0" />
-  <parameter name="PLL_NIOS_CLK_PHASE_PS_SIM_STR_PARAM" value="" />
-  <parameter name="PLL_NIOS_CLK_MULT_PARAM" value="0" />
-  <parameter name="PLL_NIOS_CLK_DIV_PARAM" value="0" />
-  <parameter name="PLL_CONFIG_CLK_FREQ_PARAM" value="0.0" />
-  <parameter name="PLL_CONFIG_CLK_FREQ_SIM_STR_PARAM" value="" />
-  <parameter name="PLL_CONFIG_CLK_PHASE_PS_PARAM" value="0" />
-  <parameter name="PLL_CONFIG_CLK_PHASE_PS_SIM_STR_PARAM" value="" />
-  <parameter name="PLL_CONFIG_CLK_MULT_PARAM" value="0" />
-  <parameter name="PLL_CONFIG_CLK_DIV_PARAM" value="0" />
-  <parameter name="PLL_P2C_READ_CLK_FREQ_PARAM" value="0.0" />
-  <parameter name="PLL_P2C_READ_CLK_FREQ_SIM_STR_PARAM" value="" />
-  <parameter name="PLL_P2C_READ_CLK_PHASE_PS_PARAM" value="0" />
-  <parameter name="PLL_P2C_READ_CLK_PHASE_PS_SIM_STR_PARAM" value="" />
-  <parameter name="PLL_P2C_READ_CLK_MULT_PARAM" value="0" />
-  <parameter name="PLL_P2C_READ_CLK_DIV_PARAM" value="0" />
-  <parameter name="PLL_C2P_WRITE_CLK_FREQ_PARAM" value="0.0" />
-  <parameter name="PLL_C2P_WRITE_CLK_FREQ_SIM_STR_PARAM" value="" />
-  <parameter name="PLL_C2P_WRITE_CLK_PHASE_PS_PARAM" value="0" />
-  <parameter name="PLL_C2P_WRITE_CLK_PHASE_PS_SIM_STR_PARAM" value="" />
-  <parameter name="PLL_C2P_WRITE_CLK_MULT_PARAM" value="0" />
-  <parameter name="PLL_C2P_WRITE_CLK_DIV_PARAM" value="0" />
-  <parameter name="PLL_HR_CLK_FREQ_PARAM" value="0.0" />
-  <parameter name="PLL_HR_CLK_FREQ_SIM_STR_PARAM" value="" />
-  <parameter name="PLL_HR_CLK_PHASE_PS_PARAM" value="0" />
-  <parameter name="PLL_HR_CLK_PHASE_PS_SIM_STR_PARAM" value="" />
-  <parameter name="PLL_HR_CLK_MULT_PARAM" value="0" />
-  <parameter name="PLL_HR_CLK_DIV_PARAM" value="0" />
-  <parameter name="PLL_AFI_PHY_CLK_FREQ_PARAM" value="0.0" />
-  <parameter name="PLL_AFI_PHY_CLK_FREQ_SIM_STR_PARAM" value="" />
-  <parameter name="PLL_AFI_PHY_CLK_PHASE_PS_PARAM" value="0" />
-  <parameter name="PLL_AFI_PHY_CLK_PHASE_PS_SIM_STR_PARAM" value="" />
-  <parameter name="PLL_AFI_PHY_CLK_MULT_PARAM" value="0" />
-  <parameter name="PLL_AFI_PHY_CLK_DIV_PARAM" value="0" />
-  <parameter name="PLL_CLK_PARAM_VALID" value="false" />
-  <parameter name="ENABLE_EXTRA_REPORTING" value="false" />
-  <parameter name="NUM_EXTRA_REPORT_PATH" value="10" />
-  <parameter name="ENABLE_ISS_PROBES" value="false" />
-  <parameter name="CALIB_REG_WIDTH" value="8" />
-  <parameter name="USE_SEQUENCER_BFM" value="false" />
-  <parameter name="PLL_SHARING_MODE" value="None" />
-  <parameter name="NUM_PLL_SHARING_INTERFACES" value="1" />
-  <parameter name="EXPORT_AFI_HALF_CLK" value="true" />
-  <parameter name="ABSTRACT_REAL_COMPARE_TEST" value="false" />
-  <parameter name="INCLUDE_BOARD_DELAY_MODEL" value="false" />
-  <parameter name="INCLUDE_MULTIRANK_BOARD_DELAY_MODEL" value="false" />
-  <parameter name="USE_FAKE_PHY" value="false" />
-  <parameter name="FORCE_MAX_LATENCY_COUNT_WIDTH" value="0" />
-  <parameter name="ENABLE_NON_DESTRUCTIVE_CALIB" value="false" />
-  <parameter name="ENABLE_DELAY_CHAIN_WRITE" value="false" />
-  <parameter name="TRACKING_ERROR_TEST" value="false" />
-  <parameter name="TRACKING_WATCH_TEST" value="false" />
-  <parameter name="MARGIN_VARIATION_TEST" value="false" />
-  <parameter name="EXTRA_SETTINGS" value="" />
-  <parameter name="MEM_DEVICE" value="MISSING_MODEL" />
-  <parameter name="FORCE_SYNTHESIS_LANGUAGE" value="" />
-  <parameter name="FORCED_NUM_WRITE_FR_CYCLE_SHIFTS" value="0" />
-  <parameter name="SEQUENCER_TYPE" value="NIOS" />
-  <parameter name="ADVERTIZE_SEQUENCER_SW_BUILD_FILES" value="false" />
-  <parameter name="FORCED_NON_LDC_ADDR_CMD_MEM_CK_INVERT" value="false" />
-  <parameter name="PHY_ONLY" value="false" />
-  <parameter name="SEQ_MODE" value="0" />
-  <parameter name="ADVANCED_CK_PHASES" value="false" />
-  <parameter name="COMMAND_PHASE" value="0.0" />
-  <parameter name="MEM_CK_PHASE" value="0.0" />
-  <parameter name="P2C_READ_CLOCK_ADD_PHASE" value="0.0" />
-  <parameter name="C2P_WRITE_CLOCK_ADD_PHASE" value="0.0" />
-  <parameter name="ACV_PHY_CLK_ADD_FR_PHASE" value="0.0" />
-  <parameter name="MEM_VOLTAGE" value="1.5V DDR3" />
-  <parameter name="PLL_LOCATION" value="Top_Bottom" />
-  <parameter name="SKIP_MEM_INIT" value="true" />
-  <parameter name="READ_DQ_DQS_CLOCK_SOURCE" value="INVERTED_DQS_BUS" />
-  <parameter name="DQ_INPUT_REG_USE_CLKN" value="false" />
-  <parameter name="DQS_DQSN_MODE" value="DIFFERENTIAL" />
-  <parameter name="AFI_DEBUG_INFO_WIDTH" value="32" />
-  <parameter name="CALIBRATION_MODE" value="Skip" />
-  <parameter name="NIOS_ROM_DATA_WIDTH" value="32" />
-  <parameter name="READ_FIFO_SIZE" value="8" />
-  <parameter name="PHY_CSR_ENABLED" value="false" />
-  <parameter name="PHY_CSR_CONNECTION" value="INTERNAL_JTAG" />
-  <parameter name="USER_DEBUG_LEVEL" value="0" />
-  <parameter name="TIMING_BOARD_DERATE_METHOD" value="AUTO" />
-  <parameter name="TIMING_BOARD_CK_CKN_SLEW_RATE" value="2.0" />
-  <parameter name="TIMING_BOARD_AC_SLEW_RATE" value="1.0" />
-  <parameter name="TIMING_BOARD_DQS_DQSN_SLEW_RATE" value="2.0" />
-  <parameter name="TIMING_BOARD_DQ_SLEW_RATE" value="1.0" />
-  <parameter name="TIMING_BOARD_TIS" value="0.0" />
-  <parameter name="TIMING_BOARD_TIH" value="0.0" />
-  <parameter name="TIMING_BOARD_TDS" value="0.0" />
-  <parameter name="TIMING_BOARD_TDH" value="0.0" />
-  <parameter name="TIMING_BOARD_ISI_METHOD" value="AUTO" />
-  <parameter name="TIMING_BOARD_AC_EYE_REDUCTION_SU" value="0.0" />
-  <parameter name="TIMING_BOARD_AC_EYE_REDUCTION_H" value="0.0" />
-  <parameter name="TIMING_BOARD_DQ_EYE_REDUCTION" value="0.0" />
-  <parameter name="TIMING_BOARD_DELTA_DQS_ARRIVAL_TIME" value="0.0" />
-  <parameter name="TIMING_BOARD_READ_DQ_EYE_REDUCTION" value="0.0" />
-  <parameter name="TIMING_BOARD_DELTA_READ_DQS_ARRIVAL_TIME" value="0.0" />
-  <parameter name="PACKAGE_DESKEW" value="false" />
-  <parameter name="AC_PACKAGE_DESKEW" value="false" />
-  <parameter name="TIMING_BOARD_MAX_CK_DELAY" value="0.6" />
-  <parameter name="TIMING_BOARD_MAX_DQS_DELAY" value="0.6" />
-  <parameter name="TIMING_BOARD_SKEW_CKDQS_DIMM_MIN" value="-0.01" />
-  <parameter name="TIMING_BOARD_SKEW_CKDQS_DIMM_MAX" value="0.01" />
-  <parameter name="TIMING_BOARD_SKEW_BETWEEN_DIMMS" value="0.05" />
-  <parameter name="TIMING_BOARD_SKEW_WITHIN_DQS" value="0.02" />
-  <parameter name="TIMING_BOARD_SKEW_BETWEEN_DQS" value="0.02" />
-  <parameter name="TIMING_BOARD_DQ_TO_DQS_SKEW" value="0.0" />
-  <parameter name="TIMING_BOARD_AC_SKEW" value="0.02" />
-  <parameter name="TIMING_BOARD_AC_TO_CK_SKEW" value="0.0" />
-  <parameter name="ENABLE_EXPORT_SEQ_DEBUG_BRIDGE" value="false" />
-  <parameter name="CORE_DEBUG_CONNECTION" value="EXPORT" />
-  <parameter name="ADD_EXTERNAL_SEQ_DEBUG_NIOS" value="false" />
-  <parameter name="ED_EXPORT_SEQ_DEBUG" value="false" />
-  <parameter name="ADD_EFFICIENCY_MONITOR" value="false" />
-  <parameter name="ENABLE_ABS_RAM_MEM_INIT" value="false" />
-  <parameter name="ABS_RAM_MEM_INIT_FILENAME" value="meminit" />
-  <parameter name="DLL_SHARING_MODE" value="None" />
-  <parameter name="NUM_DLL_SHARING_INTERFACES" value="1" />
-  <parameter name="OCT_SHARING_MODE" value="None" />
-  <parameter name="NUM_OCT_SHARING_INTERFACES" value="1" />
-  <parameter name="AUTO_DEVICE" value="5CSXFC6D6F31C6" />
+   enabled="1">
+  <parameter name="AUTO_DEVICE_FAMILY" value="Cyclone V" />
+  <parameter name="BURSTCOUNT_WIDTH" value="1" />
+  <parameter name="DATA_WIDTH" value="32" />
+  <parameter name="MASTER_ADDRESS_DEF" value="4194304" />
+  <parameter name="MASTER_ADDRESS_WIDTH" value="27" />
+  <parameter name="MAX_PENDING_READS" value="1" />
+  <parameter name="SLAVE_ADDRESS_WIDTH" value="20" />
+  <parameter name="SUB_WINDOW_COUNT" value="1" />
+  <parameter name="TERMINATE_SLAVE_PORT" value="false" />
  </module>
- <module kind="clock_source" version="14.0" enabled="1" name="clk_50">
-  <parameter name="clockFrequency" value="50000000" />
-  <parameter name="clockFrequencyKnown" value="true" />
-  <parameter name="inputClockFrequency" value="0" />
-  <parameter name="resetSynchronousEdges" value="DEASSERT" />
- </module>
- <module kind="clock_source" version="14.0" enabled="1" name="clk_100">
+ <module name="clk_100" kind="clock_source" version="16.1" enabled="1">
   <parameter name="clockFrequency" value="100000000" />
   <parameter name="clockFrequencyKnown" value="true" />
   <parameter name="inputClockFrequency" value="0" />
   <parameter name="resetSynchronousEdges" value="NONE" />
  </module>
- <module kind="mn_pcp" version="1.0" enabled="1" name="pcp_0">
-  <parameter name="AUTO_GENERATION_ID" value="0" />
-  <parameter name="AUTO_UNIQUE_ID" value="$${FILENAME}_pcp_0" />
-  <parameter name="AUTO_DEVICE_FAMILY" value="Cyclone V" />
-  <parameter name="AUTO_DEVICE" value="5CSXFC6D6F31C6" />
-  <parameter name="AUTO_CLK50_CLOCK_RATE" value="50000000" />
-  <parameter name="AUTO_CLK50_CLOCK_DOMAIN" value="2" />
-  <parameter name="AUTO_CLK50_RESET_DOMAIN" value="2" />
-  <parameter name="AUTO_CLK100_CLOCK_RATE" value="100000000" />
-  <parameter name="AUTO_CLK100_CLOCK_DOMAIN" value="1" />
-  <parameter name="AUTO_CLK100_RESET_DOMAIN" value="1" />
-  <parameter name="AUTO_SYNC_IRQ_INTERRUPTS_USED" value="1" />
-  <parameter name="AUTO_MAC_IRQ_INTERRUPTS_USED" value="1" />
-  <parameter name="AUTO_GP_IRQ_INTERRUPTS_USED" value="0" />
-  <parameter name="cpu0_resetCpuBridge" value="cpu_bridge" />
-  <parameter name="tcmemSize" value="20480" />
+ <module name="clk_50" kind="clock_source" version="16.1" enabled="1">
+  <parameter name="clockFrequency" value="50000000" />
+  <parameter name="clockFrequencyKnown" value="true" />
+  <parameter name="inputClockFrequency" value="0" />
+  <parameter name="resetSynchronousEdges" value="DEASSERT" />
  </module>
  <module
-   kind="altera_avalon_sysid_qsys"
-   version="14.0"
-   enabled="1"
-   name="sysid_qsys">
-  <parameter name="id" value="-1395322092" />
-  <parameter name="timestamp" value="0" />
-  <parameter name="AUTO_CLK_CLOCK_RATE" value="50000000" />
-  <parameter name="AUTO_DEVICE_FAMILY" value="Cyclone V" />
- </module>
- <module kind="mn_soc_host" version="1.0" enabled="1" name="host_0">
-  <parameter name="AUTO_GENERATION_ID" value="0" />
-  <parameter name="AUTO_UNIQUE_ID" value="$${FILENAME}_host_0" />
-  <parameter name="AUTO_DEVICE_FAMILY" value="Cyclone V" />
-  <parameter name="AUTO_DEVICE" value="5CSXFC6D6F31C6" />
-  <parameter name="AUTO_CLK50_CLOCK_RATE" value="50000000" />
-  <parameter name="AUTO_CLK50_CLOCK_DOMAIN" value="2" />
-  <parameter name="AUTO_CLK50_RESET_DOMAIN" value="2" />
-  <parameter name="AUTO_CLK100_CLOCK_RATE" value="100000000" />
-  <parameter name="AUTO_CLK100_CLOCK_DOMAIN" value="1" />
-  <parameter name="AUTO_CLK100_RESET_DOMAIN" value="1" />
-  <parameter name="AUTO_HOSTIF_IRQ_I_INTERRUPTS_USED" value="1" />
- </module>
- <module kind="openmac" version="1.0.2" enabled="1" name="openmac_0">
-  <parameter name="sys_mainClk" value="50000000" />
-  <parameter name="sys_mainClkx2" value="100000000" />
-  <parameter name="sys_dmaAddrWidth" value="27" />
-  <parameter name="gui_phyType" value="2" />
-  <parameter name="gui_phyCount" value="2" />
-  <parameter name="gui_extraSmi" value="false" />
-  <parameter name="gui_txBufLoc" value="1" />
-  <parameter name="gui_txBufSize" value="16" />
-  <parameter name="gui_txBurstSize" value="1" />
-  <parameter name="gui_rxBufLoc" value="2" />
-  <parameter name="gui_rxBufSize" value="1" />
-  <parameter name="gui_rxBurstSize" value="8" />
-  <parameter name="gui_tmrPulse" value="true" />
-  <parameter name="gui_tmrPulseEn" value="false" />
-  <parameter name="gui_tmrPulseWdt" value="10" />
-  <parameter name="gui_actEn" value="false" />
-  <parameter name="gui_sdcEn" value="true" />
-  <parameter name="AUTO_DMACLK_CLOCK_RATE" value="100000000" />
-  <parameter name="AUTO_PKTCLK_CLOCK_RATE" value="50000000" />
- </module>
- <module
+   name="com_mem"
    kind="altera_avalon_onchip_memory2"
-   version="14.0"
-   enabled="1"
-   name="com_mem">
+   version="16.1"
+   enabled="1">
   <parameter name="allowInSystemMemoryContentEditor" value="false" />
+  <parameter name="autoInitializationFileName">$${FILENAME}_com_mem</parameter>
   <parameter name="blockType" value="AUTO" />
+  <parameter name="copyInitFile" value="false" />
   <parameter name="dataWidth" value="32" />
+  <parameter name="dataWidth2" value="32" />
+  <parameter name="deviceFamily" value="Cyclone V" />
+  <parameter name="deviceFeatures">ADDRESS_STALL 1 ADVANCED_INFO 0 ALLOWS_COMPILING_OTHER_FAMILY_IP 1 ANY_QFP 0 CELL_LEVEL_BACK_ANNOTATION_DISABLED 0 COMPILER_SUPPORT 1 DSP 0 DSP_SHIFTER_BLOCK 0 DUMP_ASM_LAB_BITS_FOR_POWER 0 EMUL 1 ENABLE_ADVANCED_IO_ANALYSIS_GUI_FEATURES 1 ENABLE_PIN_PLANNER 0 ENGINEERING_SAMPLE 0 EPCS 1 ESB 0 FAKE1 0 FAKE2 0 FAKE3 0 FAMILY_LEVEL_INSTALLATION_ONLY 0 FASTEST 0 FINAL_TIMING_MODEL 0 FITTER_USE_FALLING_EDGE_DELAY 1 FPP_COMPLETELY_PLACES_AND_ROUTES_PERIPHERY 0 GENERATE_DC_ON_CURRENT_WARNING_FOR_INTERNAL_CLAMPING_DIODE 1 HARDCOPY 0 HAS_18_BIT_MULTS 1 HAS_ACE_SUPPORT 1 HAS_ACTIVE_PARALLEL_FLASH_SUPPORT 0 HAS_ADJUSTABLE_OUTPUT_IO_TIMING_MEAS_POINT 1 HAS_ADVANCED_IO_INVERTED_CORNER 1 HAS_ADVANCED_IO_POWER_SUPPORT 1 HAS_ADVANCED_IO_TIMING_SUPPORT 1 HAS_ALM_SUPPORT 1 HAS_ATOM_AND_ROUTING_POWER_MODELED_TOGETHER 0 HAS_AUTO_DERIVE_CLOCK_UNCERTAINTY_SUPPORT 1 HAS_AUTO_FIT_SUPPORT 1 HAS_BALANCED_OPT_TECHNIQUE_SUPPORT 1 HAS_BENEFICIAL_SKEW_SUPPORT 0 HAS_BITLEVEL_DRIVE_STRENGTH_CONTROL 1 HAS_BSDL_FILE_GENERATION 1 HAS_CDB_RE_NETWORK_PRESERVATION_SUPPORT 0 HAS_CGA_SUPPORT 1 HAS_CHECK_NETLIST_SUPPORT 1 HAS_CLOCK_REGION_CHECKER_ENABLED 1 HAS_CORE_JUNCTION_TEMP_DERATING 0 HAS_CROSSTALK_SUPPORT 0 HAS_CUSTOM_REGION_SUPPORT 1 HAS_DAP_JTAG_FROM_HPS 0 HAS_DATA_DRIVEN_ACVQ_HSSI_SUPPORT 1 HAS_DDB_FDI_SUPPORT 1 HAS_DESIGN_ANALYZER_SUPPORT 1 HAS_DETAILED_IO_RAIL_POWER_MODEL 1 HAS_DETAILED_LEIM_STATIC_POWER_MODEL 0 HAS_DETAILED_LE_POWER_MODEL 1 HAS_DETAILED_ROUTING_MUX_STATIC_POWER_MODEL 0 HAS_DETAILED_THERMAL_CIRCUIT_PARAMETER_SUPPORT 1 HAS_DEVICE_MIGRATION_SUPPORT 1 HAS_DIAGONAL_MIGRATION_SUPPORT 0 HAS_EMIF_TOOLKIT_SUPPORT 1 HAS_ERROR_DETECTION_SUPPORT 1 HAS_FAMILY_VARIANT_MIGRATION_SUPPORT 0 HAS_FANOUT_FREE_NODE_SUPPORT 1 HAS_FAST_FIT_SUPPORT 1 HAS_FITTER_ECO_SUPPORT 1 HAS_FIT_NETLIST_OPT_RETIME_SUPPORT 1 HAS_FIT_NETLIST_OPT_SUPPORT 1 HAS_FORMAL_VERIFICATION_SUPPORT 0 HAS_FPGA_XCHANGE_SUPPORT 1 HAS_FSAC_LUTRAM_REGISTER_PACKING_SUPPORT 1 HAS_FULL_DAT_MIN_TIMING_SUPPORT 1 HAS_FULL_INCREMENTAL_DESIGN_SUPPORT 1 HAS_FUNCTIONAL_SIMULATION_SUPPORT 0 HAS_FUNCTIONAL_VERILOG_SIMULATION_SUPPORT 1 HAS_FUNCTIONAL_VHDL_SIMULATION_SUPPORT 1 HAS_GLITCH_FILTERING_SUPPORT 1 HAS_HARDCOPYII_SUPPORT 0 HAS_HC_READY_SUPPORT 0 HAS_HIGH_SPEED_LOW_POWER_TILE_SUPPORT 0 HAS_HOLD_TIME_AVOIDANCE_ACROSS_CLOCK_SPINE_SUPPORT 1 HAS_HSPICE_WRITER_SUPPORT 1 HAS_HSSI_POWER_CALCULATOR 1 HAS_IBISO_WRITER_SUPPORT 0 HAS_ICD_DATA_IP 0 HAS_IDB_SUPPORT 1 HAS_INCREMENTAL_DAT_SUPPORT 1 HAS_INCREMENTAL_SYNTHESIS_SUPPORT 1 HAS_IO_ASSIGNMENT_ANALYSIS_SUPPORT 1 HAS_IO_DECODER 1 HAS_IO_PLACEMENT_OPTIMIZATION_SUPPORT 1 HAS_IO_PLACEMENT_USING_GEOMETRY_RULE 0 HAS_IO_PLACEMENT_USING_PHYSIC_RULE 0 HAS_IO_SMART_RECOMPILE_SUPPORT 0 HAS_JITTER_SUPPORT 1 HAS_JTAG_SLD_HUB_SUPPORT 1 HAS_LOGIC_LOCK_SUPPORT 1 HAS_MICROPROCESSOR 0 HAS_MIF_SMART_COMPILE_SUPPORT 1 HAS_MINMAX_TIMING_MODELING_SUPPORT 1 HAS_MIN_TIMING_ANALYSIS_SUPPORT 1 HAS_MUX_RESTRUCTURE_SUPPORT 1 HAS_NADDER_STYLE_CLOCKING 0 HAS_NADDER_STYLE_FF 0 HAS_NADDER_STYLE_LCELL_COMB 0 HAS_NEW_CDB_NAME_FOR_M20K_SCLR 0 HAS_NEW_HC_FLOW_SUPPORT 0 HAS_NEW_SERDES_MAX_RESOURCE_COUNT_REPORTING_SUPPORT 0 HAS_NEW_VPR_SUPPORT 1 HAS_NONSOCKET_TECHNOLOGY_MIGRATION_SUPPORT 0 HAS_NO_HARDBLOCK_PARTITION_SUPPORT 0 HAS_NO_JTAG_USERCODE_SUPPORT 0 HAS_OPERATING_SETTINGS_AND_CONDITIONS_REPORTING_SUPPORT 1 HAS_PAD_LOCATION_ASSIGNMENT_SUPPORT 0 HAS_PARTIAL_RECONFIG_SUPPORT 1 HAS_PASSIVE_PARALLEL_SUPPORT 0 HAS_PDN_MODEL_STATUS 0 HAS_PHYSICAL_DESIGN_PLANNER_SUPPORT 0 HAS_PHYSICAL_NETLIST_OUTPUT 0 HAS_PHYSICAL_ROUTING_SUPPORT 1 HAS_PIN_SPECIFIC_VOLTAGE_SUPPORT 1 HAS_PLDM_REF_SUPPORT 0 HAS_POWER_BINNING_LIMITS_DATA 1 HAS_POWER_ESTIMATION_SUPPORT 1 HAS_PRELIMINARY_CLOCK_UNCERTAINTY_NUMBERS 0 HAS_PRE_FITTER_FPP_SUPPORT 1 HAS_PRE_FITTER_LUTRAM_NETLIST_CHECKER_ENABLED 1 HAS_PVA_SUPPORT 1 HAS_QUARTUS_HIERARCHICAL_DESIGN_SUPPORT 0 HAS_RAPID_RECOMPILE_SUPPORT 1 HAS_RCF_SUPPORT 1 HAS_RCF_SUPPORT_FOR_DEBUGGING 0 HAS_RED_BLACK_SEPARATION_SUPPORT 0 HAS_RE_LEVEL_TIMING_GRAPH_SUPPORT 1 HAS_RISEFALL_DELAY_SUPPORT 1 HAS_SIGNAL_PROBE_SUPPORT 1 HAS_SIGNAL_TAP_SUPPORT 1 HAS_SIMULATOR_SUPPORT 0 HAS_SPLIT_IO_SUPPORT 1 HAS_SPLIT_LC_SUPPORT 1 HAS_STRICT_PRESERVATION_SUPPORT 1 HAS_SYNTHESIS_ON_ATOMS 1 HAS_SYNTH_FSYN_NETLIST_OPT_SUPPORT 1 HAS_SYNTH_NETLIST_OPT_RETIME_SUPPORT 0 HAS_SYNTH_NETLIST_OPT_SUPPORT 1 HAS_TCL_FITTER_SUPPORT 0 HAS_TECHNOLOGY_MIGRATION_SUPPORT 0 HAS_TEMPLATED_REGISTER_PACKING_SUPPORT 1 HAS_TIME_BORROWING_SUPPORT 0 HAS_TIMING_DRIVEN_SYNTHESIS_SUPPORT 1 HAS_TIMING_INFO_SUPPORT 1 HAS_TIMING_OPERATING_CONDITIONS 1 HAS_TIMING_SIMULATION_SUPPORT 0 HAS_TITAN_BASED_MAC_REGISTER_PACKER_SUPPORT 1 HAS_U2B2_SUPPORT 0 HAS_USER_HIGH_SPEED_LOW_POWER_TILE_SUPPORT 0 HAS_USE_FITTER_INFO_SUPPORT 0 HAS_VCCPD_POWER_RAIL 1 HAS_VERTICAL_MIGRATION_SUPPORT 1 HAS_VIEWDRAW_SYMBOL_SUPPORT 0 HAS_VIO_SUPPORT 1 HAS_VIRTUAL_DEVICES 0 HAS_WYSIWYG_DFFEAS_SUPPORT 1 HAS_XIBISO2_WRITER_SUPPORT 0 HAS_XIBISO_WRITER_SUPPORT 1 IFP_USE_LEGACY_IO_CHECKER 1 INCREMENTAL_DESIGN_SUPPORTS_COMPATIBLE_CONSTRAINTS 0 INSTALLED 0 INTERNAL_POF_SUPPORT_ENABLED 0 INTERNAL_USE_ONLY 0 ISSUE_MILITARY_TEMPERATURE_WARNING 0 IS_BARE_DIE 0 IS_CONFIG_ROM 0 IS_DEFAULT_FAMILY 0 IS_FOR_INTERNAL_TESTING_ONLY 0 IS_HARDCOPY_FAMILY 0 IS_HBGA_PACKAGE 0 IS_HIGH_CURRENT_PART 0 IS_LOW_POWER_PART 0 IS_SDM_ONLY_PACKAGE 0 IS_SMI_PART 0 LOAD_BLK_TYPE_DATA_FROM_ATOM_WYS_INFO 0 LVDS_IO 1 M10K_MEMORY 1 M144K_MEMORY 0 M20K_MEMORY 0 M4K_MEMORY 0 M512_MEMORY 0 M9K_MEMORY 0 MLAB_MEMORY 1 MRAM_MEMORY 0 NOT_LISTED 0 NOT_MIGRATABLE 0 NO_FITTER_DELAY_CACHE_GENERATED 0 NO_PIN_OUT 0 NO_POF 0 NO_RPE_SUPPORT 0 NO_SUPPORT_FOR_LOGICLOCK_CONTENT_BACK_ANNOTATION 1 NO_SUPPORT_FOR_STA_CLOCK_UNCERTAINTY_CHECK 0 NO_TDC_SUPPORT 0 POSTFIT_BAK_DATABASE_EXPORT_ENABLED 1 POSTMAP_BAK_DATABASE_EXPORT_ENABLED 1 PROGRAMMER_ONLY 0 PROGRAMMER_SUPPORT 1 PVA_SUPPORTS_ONLY_SUBSET_OF_ATOMS 0 QFIT_IN_DEVELOPMENT 0 QMAP_IN_DEVELOPMENT 0 RAM_LOGICAL_NAME_CHECKING_IN_CUT_ENABLED 1 REPORTS_METASTABILITY_MTBF 1 REQUIRES_INSTALLATION_PATCH 0 REQUIRES_LIST_OF_TEMPERATURE_AND_VOLTAGE_OPERATING_CONDITIONS 1 REQUIRE_QUARTUS_HIERARCHICAL_DESIGN 0 REQUIRE_SPECIAL_HANDLING_FOR_LOCAL_LABLINE 0 RESERVES_SIGNAL_PROBE_PINS 0 RESOLVE_MAX_FANOUT_EARLY 1 RESOLVE_MAX_FANOUT_LATE 0 RESPECTS_FIXED_SIZED_LOCKED_LOCATION_LOGICLOCK 1 RESTRICTED_USER_SELECTION 0 RESTRICT_PARTIAL_RECONFIG 0 RISEFALL_SUPPORT_IS_HIDDEN 0 SHOW_HIDDEN_FAMILY_IN_PROGRAMMER 0 STRICT_TIMING_DB_CHECKS 0 SUPPORTS_ADDITIONAL_OPTIONS_FOR_UNUSED_IO 1 SUPPORTS_CRC 1 SUPPORTS_DIFFERENTIAL_AIOT_BOARD_TRACE_MODEL 1 SUPPORTS_DSP_BALANCING_BACK_ANNOTATION 0 SUPPORTS_GENERATION_OF_EARLY_POWER_ESTIMATOR_FILE 1 SUPPORTS_GLOBAL_SIGNAL_BACK_ANNOTATION 1 SUPPORTS_HIPI_RETIMING 0 SUPPORTS_LICENSE_FREE_PARTIAL_RECONFIG 0 SUPPORTS_MAC_CHAIN_OUT_ADDER 1 SUPPORTS_RAM_PACKING_BACK_ANNOTATION 0 SUPPORTS_REG_PACKING_BACK_ANNOTATION 0 SUPPORTS_SIGNALPROBE_REGISTER_PIPELINING 1 SUPPORTS_SINGLE_ENDED_AIOT_BOARD_TRACE_MODEL 1 SUPPORTS_USER_MANUAL_LOGIC_DUPLICATION 1 SUPPORTS_VID 0 TMV_RUN_CUSTOMIZABLE_VIEWER 1 TMV_RUN_INTERNAL_DETAILS 1 TMV_RUN_INTERNAL_DETAILS_ON_IO 0 TMV_RUN_INTERNAL_DETAILS_ON_IOBUF 1 TMV_RUN_INTERNAL_DETAILS_ON_LCELL 0 TMV_RUN_INTERNAL_DETAILS_ON_LRAM 0 TRANSCEIVER_3G_BLOCK 1 TRANSCEIVER_6G_BLOCK 1 USES_ACV_FOR_FLED 1 USES_ADB_FOR_BACK_ANNOTATION 1 USES_ALTERA_LNSIM 0 USES_ASIC_ROUTING_POWER_CALCULATOR 0 USES_DATA_DRIVEN_PLL_COMPUTATION_UTIL 1 USES_DEV 1 USES_ICP_FOR_ECO_FITTER 0 USES_LIBERTY_TIMING 0 USES_NETWORK_ROUTING_POWER_CALCULATOR 0 USES_PART_INFO_FOR_DISPLAYING_CORE_VOLTAGE_VALUE 0 USES_POWER_SIGNAL_ACTIVITIES 1 USES_PVAFAM2 0 USES_SECOND_GENERATION_PART_INFO 0 USES_SECOND_GENERATION_POWER_ANALYZER 0 USES_THIRD_GENERATION_TIMING_MODELS_TIS 1 USES_U2B2_TIMING_MODELS 0 USES_XML_FORMAT_FOR_EMIF_PIN_MAP_FILE 0 USE_ADVANCED_IO_POWER_BY_DEFAULT 1 USE_ADVANCED_IO_TIMING_BY_DEFAULT 1 USE_BASE_FAMILY_DDB_PATH 0 USE_OCT_AUTO_CALIBRATION 1 USE_RELAX_IO_ASSIGNMENT_RULES 0 USE_RISEFALL_ONLY 1 USE_SEPARATE_LIST_FOR_TECH_MIGRATION 0 USE_SINGLE_COMPILER_PASS_PLL_MIF_FILE_WRITER 1 USE_TITAN_IO_BASED_IO_REGISTER_PACKER_UTIL 1 USING_28NM_OR_OLDER_TIMING_METHODOLOGY 1 WYSIWYG_BUS_WIDTH_CHECKING_IN_CUT_ENABLED 1</parameter>
   <parameter name="dualPort" value="true" />
+  <parameter name="ecc_enabled" value="false" />
+  <parameter name="enPRInitMode" value="false" />
+  <parameter name="enableDiffWidth" value="false" />
   <parameter name="initMemContent" value="true" />
   <parameter name="initializationFileName" value="onchip_mem.hex" />
   <parameter name="instanceID" value="NONE" />
   <parameter name="memorySize" value="4096" />
   <parameter name="readDuringWriteMode" value="DONT_CARE" />
+  <parameter name="resetrequest_enabled" value="true" />
   <parameter name="simAllowMRAMContentsFile" value="false" />
   <parameter name="simMemInitOnlyFilename" value="0" />
   <parameter name="singleClockOperation" value="false" />
@@ -697,306 +359,401 @@
   <parameter name="useNonDefaultInitFile" value="false" />
   <parameter name="useShallowMemBlocks" value="false" />
   <parameter name="writable" value="true" />
-  <parameter name="ecc_enabled" value="false" />
-  <parameter name="resetrequest_enabled" value="true" />
-  <parameter name="autoInitializationFileName">$${FILENAME}_com_mem</parameter>
-  <parameter name="deviceFamily" value="Cyclone V" />
-  <parameter name="deviceFeatures">ADDRESS_STALL 1 ADVANCED_INFO 0 ALLOWS_COMPILING_OTHER_FAMILY_IP 1 ANY_QFP 0 CELL_LEVEL_BACK_ANNOTATION_DISABLED 0 COMPILER_SUPPORT 1 DSP 0 DSP_SHIFTER_BLOCK 0 DUMP_ASM_LAB_BITS_FOR_POWER 0 EMUL 1 ENABLE_ADVANCED_IO_ANALYSIS_GUI_FEATURES 1 ENABLE_PIN_PLANNER 0 ENGINEERING_SAMPLE 0 EPCS 1 ESB 0 FAKE1 0 FAKE2 0 FAKE3 0 FAMILY_LEVEL_INSTALLATION_ONLY 0 FASTEST 0 FINAL_TIMING_MODEL 0 FITTER_USE_FALLING_EDGE_DELAY 1 GENERATE_DC_ON_CURRENT_WARNING_FOR_INTERNAL_CLAMPING_DIODE 1 HARDCOPY 0 HAS_18_BIT_MULTS 1 HAS_ACE_SUPPORT 1 HAS_ACTIVE_PARALLEL_FLASH_SUPPORT 0 HAS_ADJUSTABLE_OUTPUT_IO_TIMING_MEAS_POINT 1 HAS_ADVANCED_IO_INVERTED_CORNER 1 HAS_ADVANCED_IO_POWER_SUPPORT 1 HAS_ADVANCED_IO_TIMING_SUPPORT 1 HAS_ALM_SUPPORT 1 HAS_ATOM_AND_ROUTING_POWER_MODELED_TOGETHER 0 HAS_AUTO_DERIVE_CLOCK_UNCERTAINTY_SUPPORT 1 HAS_AUTO_FIT_SUPPORT 1 HAS_BALANCED_OPT_TECHNIQUE_SUPPORT 1 HAS_BENEFICIAL_SKEW_SUPPORT 0 HAS_BITLEVEL_DRIVE_STRENGTH_CONTROL 1 HAS_BSDL_FILE_GENERATION 1 HAS_CDB_RE_NETWORK_PRESERVATION_SUPPORT 0 HAS_CGA_SUPPORT 1 HAS_CHECK_NETLIST_SUPPORT 1 HAS_CLOCK_REGION_CHECKER_ENABLED 1 HAS_CORE_JUNCTION_TEMP_DERATING 0 HAS_CROSSTALK_SUPPORT 0 HAS_CUSTOM_REGION_SUPPORT 1 HAS_DAP_JTAG_FROM_HPS 0 HAS_DATA_DRIVEN_ACVQ_HSSI_SUPPORT 1 HAS_DDB_FDI_SUPPORT 1 HAS_DESIGN_ANALYZER_SUPPORT 1 HAS_DETAILED_IO_RAIL_POWER_MODEL 1 HAS_DETAILED_LEIM_STATIC_POWER_MODEL 0 HAS_DETAILED_LE_POWER_MODEL 1 HAS_DETAILED_ROUTING_MUX_STATIC_POWER_MODEL 0 HAS_DETAILED_THERMAL_CIRCUIT_PARAMETER_SUPPORT 1 HAS_DEVICE_MIGRATION_SUPPORT 1 HAS_DIAGONAL_MIGRATION_SUPPORT 0 HAS_EMIF_TOOLKIT_SUPPORT 1 HAS_ERROR_DETECTION_SUPPORT 1 HAS_FAMILY_VARIANT_MIGRATION_SUPPORT 0 HAS_FANOUT_FREE_NODE_SUPPORT 1 HAS_FAST_FIT_SUPPORT 1 HAS_FITTER_EARLY_TIMING_ESTIMATE_SUPPORT 0 HAS_FITTER_ECO_SUPPORT 1 HAS_FIT_NETLIST_OPT_RETIME_SUPPORT 1 HAS_FIT_NETLIST_OPT_SUPPORT 1 HAS_FORMAL_VERIFICATION_SUPPORT 1 HAS_FPGA_XCHANGE_SUPPORT 1 HAS_FSAC_LUTRAM_REGISTER_PACKING_SUPPORT 1 HAS_FULL_DAT_MIN_TIMING_SUPPORT 1 HAS_FULL_INCREMENTAL_DESIGN_SUPPORT 1 HAS_FUNCTIONAL_SIMULATION_SUPPORT 0 HAS_FUNCTIONAL_VERILOG_SIMULATION_SUPPORT 1 HAS_FUNCTIONAL_VHDL_SIMULATION_SUPPORT 1 HAS_GLITCH_FILTERING_SUPPORT 1 HAS_HARDCOPYII_SUPPORT 0 HAS_HC_READY_SUPPORT 0 HAS_HIGH_SPEED_LOW_POWER_TILE_SUPPORT 0 HAS_HOLD_TIME_AVOIDANCE_ACROSS_CLOCK_SPINE_SUPPORT 1 HAS_HSPICE_WRITER_SUPPORT 1 HAS_HSSI_POWER_CALCULATOR 1 HAS_IBISO_WRITER_SUPPORT 0 HAS_ICD_DATA_IP 0 HAS_INCREMENTAL_DAT_SUPPORT 1 HAS_INCREMENTAL_SYNTHESIS_SUPPORT 1 HAS_INTERFACE_PLANNER_SUPPORT 0 HAS_IO_ASSIGNMENT_ANALYSIS_SUPPORT 1 HAS_IO_DECODER 1 HAS_IO_PLACEMENT_OPTIMIZATION_SUPPORT 1 HAS_IO_SMART_RECOMPILE_SUPPORT 0 HAS_JITTER_SUPPORT 1 HAS_JTAG_SLD_HUB_SUPPORT 1 HAS_LIMITED_TCL_FITTER_SUPPORT 1 HAS_LOGICAL_FLOORPLANNER_SUPPORT 0 HAS_LOGIC_LOCK_SUPPORT 1 HAS_MICROPROCESSOR 0 HAS_MIF_SMART_COMPILE_SUPPORT 1 HAS_MINMAX_TIMING_MODELING_SUPPORT 1 HAS_MIN_TIMING_ANALYSIS_SUPPORT 1 HAS_MUX_RESTRUCTURE_SUPPORT 1 HAS_NEW_HC_FLOW_SUPPORT 0 HAS_NEW_SERDES_MAX_RESOURCE_COUNT_REPORTING_SUPPORT 0 HAS_NEW_VPR_SUPPORT 1 HAS_NONSOCKET_TECHNOLOGY_MIGRATION_SUPPORT 0 HAS_NO_HARDBLOCK_PARTITION_SUPPORT 0 HAS_NO_JTAG_USERCODE_SUPPORT 0 HAS_OPERATING_SETTINGS_AND_CONDITIONS_REPORTING_SUPPORT 1 HAS_PAD_LOCATION_ASSIGNMENT_SUPPORT 0 HAS_PARTIAL_RECONFIG_SUPPORT 1 HAS_PASSIVE_PARALLEL_SUPPORT 0 HAS_PHYSICAL_DESIGN_PLANNER_SUPPORT 0 HAS_PHYSICAL_NETLIST_OUTPUT 0 HAS_PHYSICAL_ROUTING_SUPPORT 1 HAS_PIN_SPECIFIC_VOLTAGE_SUPPORT 1 HAS_PLDM_REF_SUPPORT 0 HAS_POWER_BINNING_LIMITS_DATA 1 HAS_POWER_ESTIMATION_SUPPORT 1 HAS_PRELIMINARY_CLOCK_UNCERTAINTY_NUMBERS 0 HAS_PRE_FITTER_FPP_SUPPORT 1 HAS_PRE_FITTER_LUTRAM_NETLIST_CHECKER_ENABLED 1 HAS_PVA_SUPPORT 1 HAS_RAPID_RECOMPILE_SUPPORT 1 HAS_RCF_SUPPORT 1 HAS_RCF_SUPPORT_FOR_DEBUGGING 0 HAS_RED_BLACK_SEPARATION_SUPPORT 0 HAS_RE_LEVEL_TIMING_GRAPH_SUPPORT 1 HAS_RISEFALL_DELAY_SUPPORT 1 HAS_SIGNAL_PROBE_SUPPORT 1 HAS_SIGNAL_TAP_SUPPORT 1 HAS_SIMULATOR_SUPPORT 0 HAS_SPLIT_IO_SUPPORT 1 HAS_SPLIT_LC_SUPPORT 1 HAS_STRICT_PRESERVATION_SUPPORT 1 HAS_SYNTH_FSYN_NETLIST_OPT_SUPPORT 1 HAS_SYNTH_NETLIST_OPT_RETIME_SUPPORT 0 HAS_SYNTH_NETLIST_OPT_SUPPORT 1 HAS_TCL_FITTER_SUPPORT 0 HAS_TECHNOLOGY_MIGRATION_SUPPORT 0 HAS_TEMPLATED_REGISTER_PACKING_SUPPORT 1 HAS_TIME_BORROWING_SUPPORT 0 HAS_TIMING_DRIVEN_SYNTHESIS_SUPPORT 1 HAS_TIMING_INFO_SUPPORT 1 HAS_TIMING_OPERATING_CONDITIONS 1 HAS_TIMING_SIMULATION_SUPPORT 0 HAS_TITAN_BASED_MAC_REGISTER_PACKER_SUPPORT 1 HAS_U2B2_SUPPORT 0 HAS_USER_HIGH_SPEED_LOW_POWER_TILE_SUPPORT 0 HAS_USE_FITTER_INFO_SUPPORT 0 HAS_VCCPD_POWER_RAIL 1 HAS_VERTICAL_MIGRATION_SUPPORT 1 HAS_VIEWDRAW_SYMBOL_SUPPORT 0 HAS_VIO_SUPPORT 1 HAS_VIRTUAL_DEVICES 0 HAS_WYSIWYG_DFFEAS_SUPPORT 1 HAS_XIBISO_WRITER_SUPPORT 1 IFP_USE_LEGACY_IO_CHECKER 1 INCREMENTAL_DESIGN_SUPPORTS_COMPATIBLE_CONSTRAINTS 0 INSTALLED 0 INTERNAL_POF_SUPPORT_ENABLED 0 INTERNAL_USE_ONLY 0 ISSUE_MILITARY_TEMPERATURE_WARNING 0 IS_CONFIG_ROM 0 IS_DEFAULT_FAMILY 0 IS_HARDCOPY_FAMILY 0 IS_HBGA_PACKAGE 0 IS_HIGH_CURRENT_PART 0 IS_LOW_POWER_PART 0 IS_SDM_ONLY_PACKAGE 0 LVDS_IO 1 M10K_MEMORY 1 M144K_MEMORY 0 M20K_MEMORY 0 M4K_MEMORY 0 M512_MEMORY 0 M9K_MEMORY 0 MLAB_MEMORY 1 MRAM_MEMORY 0 NOT_LISTED 0 NOT_MIGRATABLE 0 NO_FITTER_DELAY_CACHE_GENERATED 0 NO_PIN_OUT 0 NO_POF 0 NO_RPE_SUPPORT 0 NO_SUPPORT_FOR_LOGICLOCK_CONTENT_BACK_ANNOTATION 1 NO_SUPPORT_FOR_STA_CLOCK_UNCERTAINTY_CHECK 0 NO_TDC_SUPPORT 0 POSTFIT_BAK_DATABASE_EXPORT_ENABLED 1 POSTMAP_BAK_DATABASE_EXPORT_ENABLED 1 PROGRAMMER_SUPPORT 1 PVA_SUPPORTS_ONLY_SUBSET_OF_ATOMS 0 QFIT_IN_DEVELOPMENT 0 QMAP_IN_DEVELOPMENT 0 RAM_LOGICAL_NAME_CHECKING_IN_CUT_ENABLED 1 REPORTS_METASTABILITY_MTBF 1 REQUIRES_INSTALLATION_PATCH 0 REQUIRES_LIST_OF_TEMPERATURE_AND_VOLTAGE_OPERATING_CONDITIONS 1 RESERVES_SIGNAL_PROBE_PINS 0 RESOLVE_MAX_FANOUT_EARLY 1 RESOLVE_MAX_FANOUT_LATE 0 RESPECTS_FIXED_SIZED_LOCKED_LOCATION_LOGICLOCK 1 RESTRICTED_USER_SELECTION 0 RISEFALL_SUPPORT_IS_HIDDEN 0 SHOW_HIDDEN_FAMILY_IN_PROGRAMMER 0 STRICT_TIMING_DB_CHECKS 0 SUPPORTS_ADDITIONAL_OPTIONS_FOR_UNUSED_IO 1 SUPPORTS_CRC 1 SUPPORTS_DIFFERENTIAL_AIOT_BOARD_TRACE_MODEL 1 SUPPORTS_DSP_BALANCING_BACK_ANNOTATION 0 SUPPORTS_GENERATION_OF_EARLY_POWER_ESTIMATOR_FILE 1 SUPPORTS_GLOBAL_SIGNAL_BACK_ANNOTATION 1 SUPPORTS_HIPI_RETIMING 0 SUPPORTS_MAC_CHAIN_OUT_ADDER 1 SUPPORTS_RAM_PACKING_BACK_ANNOTATION 0 SUPPORTS_REG_PACKING_BACK_ANNOTATION 0 SUPPORTS_SIGNALPROBE_REGISTER_PIPELINING 1 SUPPORTS_SINGLE_ENDED_AIOT_BOARD_TRACE_MODEL 1 SUPPORTS_USER_MANUAL_LOGIC_DUPLICATION 1 TMV_RUN_CUSTOMIZABLE_VIEWER 1 TMV_RUN_INTERNAL_DETAILS 1 TMV_RUN_INTERNAL_DETAILS_ON_IO 0 TMV_RUN_INTERNAL_DETAILS_ON_IOBUF 1 TMV_RUN_INTERNAL_DETAILS_ON_LCELL 0 TMV_RUN_INTERNAL_DETAILS_ON_LRAM 0 TRANSCEIVER_3G_BLOCK 1 TRANSCEIVER_6G_BLOCK 1 USES_ACV_FOR_FLED 1 USES_ADB_FOR_BACK_ANNOTATION 1 USES_ALTERA_LNSIM 0 USES_ASIC_ROUTING_POWER_CALCULATOR 0 USES_DATA_DRIVEN_PLL_COMPUTATION_UTIL 1 USES_DEV 1 USES_ICP_FOR_ECO_FITTER 0 USES_LIBERTY_TIMING 0 USES_NETWORK_ROUTING_POWER_CALCULATOR 0 USES_POWER_SIGNAL_ACTIVITIES 1 USES_PVAFAM2 0 USES_THIRD_GENERATION_TIMING_MODELS_TIS 1 USES_U2B2_TIMING_MODELS 0 USES_XML_FORMAT_FOR_EMIF_PIN_MAP_FILE 0 USE_ADVANCED_IO_POWER_BY_DEFAULT 1 USE_ADVANCED_IO_TIMING_BY_DEFAULT 1 USE_BASE_FAMILY_DDB_PATH 0 USE_OCT_AUTO_CALIBRATION 1 USE_RELAX_IO_ASSIGNMENT_RULES 0 USE_RISEFALL_ONLY 1 USE_SEPARATE_LIST_FOR_TECH_MIGRATION 0 USE_SINGLE_COMPILER_PASS_PLL_MIF_FILE_WRITER 1 USE_TITAN_IO_BASED_IO_REGISTER_PACKER_UTIL 1 USING_28NM_OR_OLDER_TIMING_METHODOLOGY 1 WYSIWYG_BUS_WIDTH_CHECKING_IN_CUT_ENABLED 1</parameter>
  </module>
  <module
-   kind="altera_address_span_extender"
-   version="14.0"
-   enabled="1"
-   name="address_span_extender_cpu_bridge">
-  <parameter name="DATA_WIDTH" value="32" />
-  <parameter name="MASTER_ADDRESS_WIDTH" value="27" />
-  <parameter name="SLAVE_ADDRESS_WIDTH" value="20" />
-  <parameter name="BURSTCOUNT_WIDTH" value="1" />
-  <parameter name="SUB_WINDOW_COUNT" value="1" />
-  <parameter name="MASTER_ADDRESS_DEF" value="0" />
-  <parameter name="TERMINATE_SLAVE_PORT" value="false" />
-  <parameter name="MAX_PENDING_READS" value="1" />
-  <parameter name="AUTO_CLOCK_CLOCK_RATE" value="100000000" />
+   name="ddr3_emif_0"
+   kind="altera_mem_if_ddr3_emif"
+   version="16.1"
+   enabled="1">
+  <parameter name="ABSTRACT_REAL_COMPARE_TEST" value="false" />
+  <parameter name="ABS_RAM_MEM_INIT_FILENAME" value="meminit" />
+  <parameter name="ACV_PHY_CLK_ADD_FR_PHASE" value="0.0" />
+  <parameter name="AC_PACKAGE_DESKEW" value="false" />
+  <parameter name="AC_ROM_USER_ADD_0" value="0_0000_0000_0000" />
+  <parameter name="AC_ROM_USER_ADD_1" value="0_0000_0000_1000" />
+  <parameter name="ADDR_ORDER" value="2" />
+  <parameter name="ADD_EFFICIENCY_MONITOR" value="false" />
+  <parameter name="ADD_EXTERNAL_SEQ_DEBUG_NIOS" value="false" />
+  <parameter name="ADVANCED_CK_PHASES" value="false" />
+  <parameter name="ADVERTIZE_SEQUENCER_SW_BUILD_FILES" value="false" />
+  <parameter name="AFI_DEBUG_INFO_WIDTH" value="32" />
+  <parameter name="ALTMEMPHY_COMPATIBLE_MODE" value="false" />
+  <parameter name="AP_MODE" value="false" />
+  <parameter name="AP_MODE_EN" value="0" />
+  <parameter name="AUTO_DEVICE" value="5CSXFC6D6F31C6" />
+  <parameter name="AUTO_DEVICE_SPEEDGRADE" value="6_H6" />
+  <parameter name="AUTO_PD_CYCLES" value="0" />
+  <parameter name="AUTO_POWERDN_EN" value="false" />
+  <parameter name="AVL_DATA_WIDTH_PORT" value="32,32,32,32,32,32" />
+  <parameter name="AVL_MAX_SIZE" value="1" />
+  <parameter name="BYTE_ENABLE" value="true" />
+  <parameter name="C2P_WRITE_CLOCK_ADD_PHASE" value="0.0" />
+  <parameter name="CALIBRATION_MODE" value="Skip" />
+  <parameter name="CALIB_REG_WIDTH" value="8" />
+  <parameter name="CFG_DATA_REORDERING_TYPE" value="INTER_BANK" />
+  <parameter name="CFG_REORDER_DATA" value="true" />
+  <parameter name="CFG_TCCD_NS" value="2.5" />
+  <parameter name="COMMAND_PHASE" value="0.0" />
+  <parameter name="CONTROLLER_LATENCY" value="5" />
+  <parameter name="CORE_DEBUG_CONNECTION" value="EXPORT" />
+  <parameter name="CPORT_TYPE_PORT">Bidirectional,Bidirectional,Bidirectional,Bidirectional,Bidirectional,Bidirectional</parameter>
+  <parameter name="CTL_AUTOPCH_EN" value="false" />
+  <parameter name="CTL_CMD_QUEUE_DEPTH" value="8" />
+  <parameter name="CTL_CSR_CONNECTION" value="INTERNAL_JTAG" />
+  <parameter name="CTL_CSR_ENABLED" value="false" />
+  <parameter name="CTL_CSR_READ_ONLY" value="1" />
+  <parameter name="CTL_DEEP_POWERDN_EN" value="false" />
+  <parameter name="CTL_DYNAMIC_BANK_ALLOCATION" value="false" />
+  <parameter name="CTL_DYNAMIC_BANK_NUM" value="4" />
+  <parameter name="CTL_ECC_AUTO_CORRECTION_ENABLED" value="false" />
+  <parameter name="CTL_ECC_ENABLED" value="false" />
+  <parameter name="CTL_ENABLE_BURST_INTERRUPT" value="false" />
+  <parameter name="CTL_ENABLE_BURST_TERMINATE" value="false" />
+  <parameter name="CTL_HRB_ENABLED" value="false" />
+  <parameter name="CTL_LOOK_AHEAD_DEPTH" value="4" />
+  <parameter name="CTL_SELF_REFRESH_EN" value="false" />
+  <parameter name="CTL_USR_REFRESH_EN" value="false" />
+  <parameter name="CTL_ZQCAL_EN" value="false" />
+  <parameter name="CUT_NEW_FAMILY_TIMING" value="true" />
+  <parameter name="DAT_DATA_WIDTH" value="32" />
+  <parameter name="DEBUG_MODE" value="false" />
+  <parameter name="DEVICE_DEPTH" value="1" />
+  <parameter name="DEVICE_FAMILY_PARAM" value="" />
+  <parameter name="DISABLE_CHILD_MESSAGING" value="false" />
+  <parameter name="DISCRETE_FLY_BY" value="true" />
+  <parameter name="DLL_SHARING_MODE" value="None" />
+  <parameter name="DQS_DQSN_MODE" value="DIFFERENTIAL" />
+  <parameter name="DQ_INPUT_REG_USE_CLKN" value="false" />
+  <parameter name="DUPLICATE_AC" value="false" />
+  <parameter name="ED_EXPORT_SEQ_DEBUG" value="false" />
+  <parameter name="ENABLE_ABS_RAM_MEM_INIT" value="false" />
+  <parameter name="ENABLE_BONDING" value="false" />
+  <parameter name="ENABLE_BURST_MERGE" value="false" />
+  <parameter name="ENABLE_CTRL_AVALON_INTERFACE" value="true" />
+  <parameter name="ENABLE_DELAY_CHAIN_WRITE" value="false" />
+  <parameter name="ENABLE_EMIT_BFM_MASTER" value="false" />
+  <parameter name="ENABLE_EXPORT_SEQ_DEBUG_BRIDGE" value="false" />
+  <parameter name="ENABLE_EXTRA_REPORTING" value="false" />
+  <parameter name="ENABLE_ISS_PROBES" value="false" />
+  <parameter name="ENABLE_NON_DESTRUCTIVE_CALIB" value="false" />
+  <parameter name="ENABLE_NON_DES_CAL" value="false" />
+  <parameter name="ENABLE_NON_DES_CAL_TEST" value="false" />
+  <parameter name="ENABLE_SEQUENCER_MARGINING_ON_BY_DEFAULT" value="false" />
+  <parameter name="ENABLE_USER_ECC" value="false" />
+  <parameter name="EXPORT_AFI_HALF_CLK" value="true" />
+  <parameter name="EXTRA_SETTINGS" value="" />
+  <parameter name="FIX_READ_LATENCY" value="8" />
+  <parameter name="FORCED_NON_LDC_ADDR_CMD_MEM_CK_INVERT" value="false" />
+  <parameter name="FORCED_NUM_WRITE_FR_CYCLE_SHIFTS" value="0" />
+  <parameter name="FORCE_DQS_TRACKING" value="AUTO" />
+  <parameter name="FORCE_MAX_LATENCY_COUNT_WIDTH" value="0" />
+  <parameter name="FORCE_SEQUENCER_TCL_DEBUG_MODE" value="false" />
+  <parameter name="FORCE_SHADOW_REGS" value="AUTO" />
+  <parameter name="FORCE_SYNTHESIS_LANGUAGE" value="" />
+  <parameter name="HARD_EMIF" value="true" />
+  <parameter name="HCX_COMPAT_MODE" value="false" />
+  <parameter name="HHP_HPS" value="false" />
+  <parameter name="HHP_HPS_SIMULATION" value="false" />
+  <parameter name="HHP_HPS_VERIFICATION" value="false" />
+  <parameter name="HPS_PROTOCOL" value="DEFAULT" />
+  <parameter name="INCLUDE_BOARD_DELAY_MODEL" value="false" />
+  <parameter name="INCLUDE_MULTIRANK_BOARD_DELAY_MODEL" value="false" />
+  <parameter name="IS_ES_DEVICE" value="false" />
+  <parameter name="LOCAL_ID_WIDTH" value="8" />
+  <parameter name="LRDIMM_EXTENDED_CONFIG">0x000000000000000000</parameter>
+  <parameter name="MARGIN_VARIATION_TEST" value="false" />
+  <parameter name="MAX_PENDING_RD_CMD" value="16" />
+  <parameter name="MAX_PENDING_WR_CMD" value="8" />
+  <parameter name="MEM_ASR" value="Manual" />
+  <parameter name="MEM_ATCL" value="Disabled" />
+  <parameter name="MEM_AUTO_LEVELING_MODE" value="true" />
+  <parameter name="MEM_BANKADDR_WIDTH" value="3" />
+  <parameter name="MEM_BL" value="OTF" />
+  <parameter name="MEM_BT" value="Sequential" />
+  <parameter name="MEM_CK_PHASE" value="0.0" />
+  <parameter name="MEM_CK_WIDTH" value="1" />
+  <parameter name="MEM_CLK_EN_WIDTH" value="1" />
+  <parameter name="MEM_CLK_FREQ" value="300.0" />
+  <parameter name="MEM_CLK_FREQ_MAX" value="800.0" />
+  <parameter name="MEM_COL_ADDR_WIDTH" value="10" />
+  <parameter name="MEM_CS_WIDTH" value="1" />
+  <parameter name="MEM_DEVICE" value="MISSING_MODEL" />
+  <parameter name="MEM_DLL_EN" value="true" />
+  <parameter name="MEM_DQ_PER_DQS" value="8" />
+  <parameter name="MEM_DQ_WIDTH" value="32" />
+  <parameter name="MEM_DRV_STR" value="RZQ/6" />
+  <parameter name="MEM_FORMAT" value="DISCRETE" />
+  <parameter name="MEM_GUARANTEED_WRITE_INIT" value="false" />
+  <parameter name="MEM_IF_BOARD_BASE_DELAY" value="10" />
+  <parameter name="MEM_IF_DM_PINS_EN" value="true" />
+  <parameter name="MEM_IF_DQSN_EN" value="true" />
+  <parameter name="MEM_IF_SIM_VALID_WINDOW" value="0" />
+  <parameter name="MEM_INIT_EN" value="false" />
+  <parameter name="MEM_INIT_FILE" value="" />
+  <parameter name="MEM_MIRROR_ADDRESSING" value="0" />
+  <parameter name="MEM_NUMBER_OF_DIMMS" value="1" />
+  <parameter name="MEM_NUMBER_OF_RANKS_PER_DEVICE" value="1" />
+  <parameter name="MEM_NUMBER_OF_RANKS_PER_DIMM" value="1" />
+  <parameter name="MEM_PD" value="DLL off" />
+  <parameter name="MEM_RANK_MULTIPLICATION_FACTOR" value="1" />
+  <parameter name="MEM_ROW_ADDR_WIDTH" value="12" />
+  <parameter name="MEM_RTT_NOM" value="ODT Disabled" />
+  <parameter name="MEM_RTT_WR" value="Dynamic ODT off" />
+  <parameter name="MEM_SRT" value="Normal" />
+  <parameter name="MEM_TCL" value="6" />
+  <parameter name="MEM_TFAW_NS" value="40.0" />
+  <parameter name="MEM_TINIT_US" value="500" />
+  <parameter name="MEM_TMRD_CK" value="4" />
+  <parameter name="MEM_TRAS_NS" value="35.0" />
+  <parameter name="MEM_TRCD_NS" value="13.75" />
+  <parameter name="MEM_TREFI_US" value="7.8" />
+  <parameter name="MEM_TRFC_NS" value="260.0" />
+  <parameter name="MEM_TRP_NS" value="13.75" />
+  <parameter name="MEM_TRRD_NS" value="13.5" />
+  <parameter name="MEM_TRTP_NS" value="13.5" />
+  <parameter name="MEM_TWR_NS" value="15.0" />
+  <parameter name="MEM_TWTR" value="4" />
+  <parameter name="MEM_USER_LEVELING_MODE" value="Leveling" />
+  <parameter name="MEM_VENDOR" value="Micron" />
+  <parameter name="MEM_VERBOSE" value="true" />
+  <parameter name="MEM_VOLTAGE" value="1.5V DDR3" />
+  <parameter name="MEM_WTCL" value="5" />
+  <parameter name="MRS_MIRROR_PING_PONG_ATSO" value="false" />
+  <parameter name="MULTICAST_EN" value="false" />
+  <parameter name="NEXTGEN" value="true" />
+  <parameter name="NIOS_ROM_DATA_WIDTH" value="32" />
+  <parameter name="NUM_DLL_SHARING_INTERFACES" value="1" />
+  <parameter name="NUM_EXTRA_REPORT_PATH" value="10" />
+  <parameter name="NUM_OCT_SHARING_INTERFACES" value="1" />
+  <parameter name="NUM_OF_PORTS" value="1" />
+  <parameter name="NUM_PLL_SHARING_INTERFACES" value="1" />
+  <parameter name="OCT_SHARING_MODE" value="None" />
+  <parameter name="P2C_READ_CLOCK_ADD_PHASE" value="0.0" />
+  <parameter name="PACKAGE_DESKEW" value="false" />
+  <parameter name="PARSE_FRIENDLY_DEVICE_FAMILY_PARAM" value="" />
+  <parameter name="PARSE_FRIENDLY_DEVICE_FAMILY_PARAM_VALID" value="false" />
+  <parameter name="PHY_CSR_CONNECTION" value="INTERNAL_JTAG" />
+  <parameter name="PHY_CSR_ENABLED" value="false" />
+  <parameter name="PHY_ONLY" value="false" />
+  <parameter name="PINGPONGPHY_EN" value="false" />
+  <parameter name="PLL_ADDR_CMD_CLK_DIV_PARAM" value="0" />
+  <parameter name="PLL_ADDR_CMD_CLK_FREQ_PARAM" value="0.0" />
+  <parameter name="PLL_ADDR_CMD_CLK_FREQ_SIM_STR_PARAM" value="" />
+  <parameter name="PLL_ADDR_CMD_CLK_MULT_PARAM" value="0" />
+  <parameter name="PLL_ADDR_CMD_CLK_PHASE_PS_PARAM" value="0" />
+  <parameter name="PLL_ADDR_CMD_CLK_PHASE_PS_SIM_STR_PARAM" value="" />
+  <parameter name="PLL_AFI_CLK_DIV_PARAM" value="0" />
+  <parameter name="PLL_AFI_CLK_FREQ_PARAM" value="0.0" />
+  <parameter name="PLL_AFI_CLK_FREQ_SIM_STR_PARAM" value="" />
+  <parameter name="PLL_AFI_CLK_MULT_PARAM" value="0" />
+  <parameter name="PLL_AFI_CLK_PHASE_PS_PARAM" value="0" />
+  <parameter name="PLL_AFI_CLK_PHASE_PS_SIM_STR_PARAM" value="" />
+  <parameter name="PLL_AFI_HALF_CLK_DIV_PARAM" value="0" />
+  <parameter name="PLL_AFI_HALF_CLK_FREQ_PARAM" value="0.0" />
+  <parameter name="PLL_AFI_HALF_CLK_FREQ_SIM_STR_PARAM" value="" />
+  <parameter name="PLL_AFI_HALF_CLK_MULT_PARAM" value="0" />
+  <parameter name="PLL_AFI_HALF_CLK_PHASE_PS_PARAM" value="0" />
+  <parameter name="PLL_AFI_HALF_CLK_PHASE_PS_SIM_STR_PARAM" value="" />
+  <parameter name="PLL_AFI_PHY_CLK_DIV_PARAM" value="0" />
+  <parameter name="PLL_AFI_PHY_CLK_FREQ_PARAM" value="0.0" />
+  <parameter name="PLL_AFI_PHY_CLK_FREQ_SIM_STR_PARAM" value="" />
+  <parameter name="PLL_AFI_PHY_CLK_MULT_PARAM" value="0" />
+  <parameter name="PLL_AFI_PHY_CLK_PHASE_PS_PARAM" value="0" />
+  <parameter name="PLL_AFI_PHY_CLK_PHASE_PS_SIM_STR_PARAM" value="" />
+  <parameter name="PLL_C2P_WRITE_CLK_DIV_PARAM" value="0" />
+  <parameter name="PLL_C2P_WRITE_CLK_FREQ_PARAM" value="0.0" />
+  <parameter name="PLL_C2P_WRITE_CLK_FREQ_SIM_STR_PARAM" value="" />
+  <parameter name="PLL_C2P_WRITE_CLK_MULT_PARAM" value="0" />
+  <parameter name="PLL_C2P_WRITE_CLK_PHASE_PS_PARAM" value="0" />
+  <parameter name="PLL_C2P_WRITE_CLK_PHASE_PS_SIM_STR_PARAM" value="" />
+  <parameter name="PLL_CLK_PARAM_VALID" value="false" />
+  <parameter name="PLL_CONFIG_CLK_DIV_PARAM" value="0" />
+  <parameter name="PLL_CONFIG_CLK_FREQ_PARAM" value="0.0" />
+  <parameter name="PLL_CONFIG_CLK_FREQ_SIM_STR_PARAM" value="" />
+  <parameter name="PLL_CONFIG_CLK_MULT_PARAM" value="0" />
+  <parameter name="PLL_CONFIG_CLK_PHASE_PS_PARAM" value="0" />
+  <parameter name="PLL_CONFIG_CLK_PHASE_PS_SIM_STR_PARAM" value="" />
+  <parameter name="PLL_DR_CLK_DIV_PARAM" value="0" />
+  <parameter name="PLL_DR_CLK_FREQ_PARAM" value="0.0" />
+  <parameter name="PLL_DR_CLK_FREQ_SIM_STR_PARAM" value="" />
+  <parameter name="PLL_DR_CLK_MULT_PARAM" value="0" />
+  <parameter name="PLL_DR_CLK_PHASE_PS_PARAM" value="0" />
+  <parameter name="PLL_DR_CLK_PHASE_PS_SIM_STR_PARAM" value="" />
+  <parameter name="PLL_HR_CLK_DIV_PARAM" value="0" />
+  <parameter name="PLL_HR_CLK_FREQ_PARAM" value="0.0" />
+  <parameter name="PLL_HR_CLK_FREQ_SIM_STR_PARAM" value="" />
+  <parameter name="PLL_HR_CLK_MULT_PARAM" value="0" />
+  <parameter name="PLL_HR_CLK_PHASE_PS_PARAM" value="0" />
+  <parameter name="PLL_HR_CLK_PHASE_PS_SIM_STR_PARAM" value="" />
+  <parameter name="PLL_LOCATION" value="Top_Bottom" />
+  <parameter name="PLL_MEM_CLK_DIV_PARAM" value="0" />
+  <parameter name="PLL_MEM_CLK_FREQ_PARAM" value="0.0" />
+  <parameter name="PLL_MEM_CLK_FREQ_SIM_STR_PARAM" value="" />
+  <parameter name="PLL_MEM_CLK_MULT_PARAM" value="0" />
+  <parameter name="PLL_MEM_CLK_PHASE_PS_PARAM" value="0" />
+  <parameter name="PLL_MEM_CLK_PHASE_PS_SIM_STR_PARAM" value="" />
+  <parameter name="PLL_NIOS_CLK_DIV_PARAM" value="0" />
+  <parameter name="PLL_NIOS_CLK_FREQ_PARAM" value="0.0" />
+  <parameter name="PLL_NIOS_CLK_FREQ_SIM_STR_PARAM" value="" />
+  <parameter name="PLL_NIOS_CLK_MULT_PARAM" value="0" />
+  <parameter name="PLL_NIOS_CLK_PHASE_PS_PARAM" value="0" />
+  <parameter name="PLL_NIOS_CLK_PHASE_PS_SIM_STR_PARAM" value="" />
+  <parameter name="PLL_P2C_READ_CLK_DIV_PARAM" value="0" />
+  <parameter name="PLL_P2C_READ_CLK_FREQ_PARAM" value="0.0" />
+  <parameter name="PLL_P2C_READ_CLK_FREQ_SIM_STR_PARAM" value="" />
+  <parameter name="PLL_P2C_READ_CLK_MULT_PARAM" value="0" />
+  <parameter name="PLL_P2C_READ_CLK_PHASE_PS_PARAM" value="0" />
+  <parameter name="PLL_P2C_READ_CLK_PHASE_PS_SIM_STR_PARAM" value="" />
+  <parameter name="PLL_SHARING_MODE" value="None" />
+  <parameter name="PLL_WRITE_CLK_DIV_PARAM" value="0" />
+  <parameter name="PLL_WRITE_CLK_FREQ_PARAM" value="0.0" />
+  <parameter name="PLL_WRITE_CLK_FREQ_SIM_STR_PARAM" value="" />
+  <parameter name="PLL_WRITE_CLK_MULT_PARAM" value="0" />
+  <parameter name="PLL_WRITE_CLK_PHASE_PS_PARAM" value="0" />
+  <parameter name="PLL_WRITE_CLK_PHASE_PS_SIM_STR_PARAM" value="" />
+  <parameter name="POWER_OF_TWO_BUS" value="false" />
+  <parameter name="PRIORITY_PORT" value="1,1,1,1,1,1" />
+  <parameter name="RATE" value="Full" />
+  <parameter name="RDIMM_CONFIG" value="0000000000000000" />
+  <parameter name="READ_DQ_DQS_CLOCK_SOURCE" value="INVERTED_DQS_BUS" />
+  <parameter name="READ_FIFO_SIZE" value="8" />
+  <parameter name="REFRESH_BURST_VALIDATION" value="false" />
+  <parameter name="REFRESH_INTERVAL" value="15000" />
+  <parameter name="REF_CLK_FREQ" value="50.0" />
+  <parameter name="REF_CLK_FREQ_MAX_PARAM" value="0.0" />
+  <parameter name="REF_CLK_FREQ_MIN_PARAM" value="0.0" />
+  <parameter name="REF_CLK_FREQ_PARAM_VALID" value="false" />
+  <parameter name="SEQUENCER_TYPE" value="NIOS" />
+  <parameter name="SEQ_MODE" value="0" />
+  <parameter name="SKIP_MEM_INIT" value="true" />
+  <parameter name="SOPC_COMPAT_RESET" value="false" />
+  <parameter name="SPEED_GRADE" value="8" />
+  <parameter name="STARVE_LIMIT" value="10" />
+  <parameter name="SYS_INFO_DEVICE_FAMILY" value="Cyclone V" />
+  <parameter name="TIMING_BOARD_AC_EYE_REDUCTION_H" value="0.0" />
+  <parameter name="TIMING_BOARD_AC_EYE_REDUCTION_SU" value="0.0" />
+  <parameter name="TIMING_BOARD_AC_SKEW" value="0.02" />
+  <parameter name="TIMING_BOARD_AC_SLEW_RATE" value="1.0" />
+  <parameter name="TIMING_BOARD_AC_TO_CK_SKEW" value="0.0" />
+  <parameter name="TIMING_BOARD_CK_CKN_SLEW_RATE" value="2.0" />
+  <parameter name="TIMING_BOARD_DELTA_DQS_ARRIVAL_TIME" value="0.0" />
+  <parameter name="TIMING_BOARD_DELTA_READ_DQS_ARRIVAL_TIME" value="0.0" />
+  <parameter name="TIMING_BOARD_DERATE_METHOD" value="AUTO" />
+  <parameter name="TIMING_BOARD_DQS_DQSN_SLEW_RATE" value="2.0" />
+  <parameter name="TIMING_BOARD_DQ_EYE_REDUCTION" value="0.0" />
+  <parameter name="TIMING_BOARD_DQ_SLEW_RATE" value="1.0" />
+  <parameter name="TIMING_BOARD_DQ_TO_DQS_SKEW" value="0.0" />
+  <parameter name="TIMING_BOARD_ISI_METHOD" value="AUTO" />
+  <parameter name="TIMING_BOARD_MAX_CK_DELAY" value="0.6" />
+  <parameter name="TIMING_BOARD_MAX_DQS_DELAY" value="0.6" />
+  <parameter name="TIMING_BOARD_READ_DQ_EYE_REDUCTION" value="0.0" />
+  <parameter name="TIMING_BOARD_SKEW_BETWEEN_DIMMS" value="0.05" />
+  <parameter name="TIMING_BOARD_SKEW_BETWEEN_DQS" value="0.02" />
+  <parameter name="TIMING_BOARD_SKEW_CKDQS_DIMM_MAX" value="0.01" />
+  <parameter name="TIMING_BOARD_SKEW_CKDQS_DIMM_MIN" value="-0.01" />
+  <parameter name="TIMING_BOARD_SKEW_WITHIN_DQS" value="0.02" />
+  <parameter name="TIMING_BOARD_TDH" value="0.0" />
+  <parameter name="TIMING_BOARD_TDS" value="0.0" />
+  <parameter name="TIMING_BOARD_TIH" value="0.0" />
+  <parameter name="TIMING_BOARD_TIS" value="0.0" />
+  <parameter name="TIMING_TDH" value="45" />
+  <parameter name="TIMING_TDQSCK" value="255" />
+  <parameter name="TIMING_TDQSCKDL" value="1200" />
+  <parameter name="TIMING_TDQSCKDM" value="900" />
+  <parameter name="TIMING_TDQSCKDS" value="450" />
+  <parameter name="TIMING_TDQSQ" value="100" />
+  <parameter name="TIMING_TDQSS" value="0.27" />
+  <parameter name="TIMING_TDS" value="10" />
+  <parameter name="TIMING_TDSH" value="0.18" />
+  <parameter name="TIMING_TDSS" value="0.18" />
+  <parameter name="TIMING_TIH" value="120" />
+  <parameter name="TIMING_TIS" value="170" />
+  <parameter name="TIMING_TQH" value="0.38" />
+  <parameter name="TIMING_TQSH" value="0.4" />
+  <parameter name="TRACKING_ERROR_TEST" value="false" />
+  <parameter name="TRACKING_WATCH_TEST" value="false" />
+  <parameter name="TREFI" value="35100" />
+  <parameter name="TRFC" value="350" />
+  <parameter name="USER_DEBUG_LEVEL" value="0" />
+  <parameter name="USE_AXI_ADAPTOR" value="false" />
+  <parameter name="USE_FAKE_PHY" value="false" />
+  <parameter name="USE_MEM_CLK_FREQ" value="false" />
+  <parameter name="USE_MM_ADAPTOR" value="true" />
+  <parameter name="USE_SEQUENCER_BFM" value="false" />
+  <parameter name="WEIGHT_PORT" value="0,0,0,0,0,0" />
+  <parameter name="WRBUFFER_ADDR_WIDTH" value="6" />
+ </module>
+ <module name="host_0" kind="mn_soc_host" version="1.0" enabled="1">
+  <parameter name="AUTO_CLK100_CLOCK_DOMAIN" value="1" />
+  <parameter name="AUTO_CLK100_CLOCK_RATE" value="100000000" />
+  <parameter name="AUTO_CLK100_RESET_DOMAIN" value="1" />
+  <parameter name="AUTO_CLK50_CLOCK_DOMAIN" value="2" />
+  <parameter name="AUTO_CLK50_CLOCK_RATE" value="50000000" />
+  <parameter name="AUTO_CLK50_RESET_DOMAIN" value="2" />
+  <parameter name="AUTO_DEVICE" value="5CSXFC6D6F31C6" />
   <parameter name="AUTO_DEVICE_FAMILY" value="Cyclone V" />
+  <parameter name="AUTO_DEVICE_SPEEDGRADE" value="6_H6" />
+  <parameter name="AUTO_FPGA_MEM_ADDRESS_MAP"><![CDATA[<address-map><slave name='ddr3_emif_0.avl_0' start='0x0' end='0x8000000' /></address-map>]]></parameter>
+  <parameter name="AUTO_FPGA_MEM_ADDRESS_WIDTH" value="AddressWidth = 27" />
+  <parameter name="AUTO_GENERATION_ID" value="0" />
+  <parameter name="AUTO_HOSTIF_IRQ_I_INTERRUPTS_USED" value="1" />
+  <parameter name="AUTO_LW_BRIDGE_M0_ADDRESS_MAP"><![CDATA[<address-map><slave name='com_mem.s1' start='0x0' end='0x1000' /><slave name='sysid_qsys.control_slave' start='0x6A00' end='0x6A08' /></address-map>]]></parameter>
+  <parameter name="AUTO_LW_BRIDGE_M0_ADDRESS_WIDTH" value="AddressWidth = 15" />
+  <parameter name="AUTO_UNIQUE_ID" value="$${FILENAME}_host_0" />
+ </module>
+ <module name="openmac_0" kind="openmac" version="1.0.2" enabled="1">
+  <parameter name="gui_actEn" value="false" />
+  <parameter name="gui_extraSmi" value="false" />
+  <parameter name="gui_phyCount" value="2" />
+  <parameter name="gui_phyType" value="2" />
+  <parameter name="gui_rxBufLoc" value="2" />
+  <parameter name="gui_rxBufSize" value="1" />
+  <parameter name="gui_rxBurstSize" value="8" />
+  <parameter name="gui_sdcEn" value="true" />
+  <parameter name="gui_tmrPulse" value="true" />
+  <parameter name="gui_tmrPulseEn" value="false" />
+  <parameter name="gui_tmrPulseWdt" value="10" />
+  <parameter name="gui_txBufLoc" value="1" />
+  <parameter name="gui_txBufSize" value="16" />
+  <parameter name="gui_txBurstSize" value="1" />
+  <parameter name="sys_dmaAddrWidth" value="27" />
+  <parameter name="sys_mainClk" value="50000000" />
+  <parameter name="sys_mainClkx2" value="100000000" />
+ </module>
+ <module name="pcp_0" kind="mn_pcp" version="1.0" enabled="1">
+  <parameter name="AUTO_CLK100_CLOCK_DOMAIN" value="1" />
+  <parameter name="AUTO_CLK100_CLOCK_RATE" value="100000000" />
+  <parameter name="AUTO_CLK100_RESET_DOMAIN" value="1" />
+  <parameter name="AUTO_CLK50_CLOCK_DOMAIN" value="2" />
+  <parameter name="AUTO_CLK50_CLOCK_RATE" value="50000000" />
+  <parameter name="AUTO_CLK50_RESET_DOMAIN" value="2" />
+  <parameter name="AUTO_CPU_BRIDGE_ADDRESS_MAP"><![CDATA[<address-map><slave name='address_span_extender_cpu_bridge.windowed_slave' start='0x0' end='0x400000' /></address-map>]]></parameter>
+  <parameter name="AUTO_CPU_BRIDGE_ADDRESS_WIDTH" value="AddressWidth = 22" />
+  <parameter name="AUTO_DEVICE" value="5CSXFC6D6F31C6" />
+  <parameter name="AUTO_DEVICE_FAMILY" value="Cyclone V" />
+  <parameter name="AUTO_DEVICE_SPEEDGRADE" value="6_H6" />
+  <parameter name="AUTO_FLASH_BRIDGE_ADDRESS_MAP"><![CDATA[<address-map><slave name='address_span_extender_flash_bridge.windowed_slave' start='0x0' end='0x400000' /></address-map>]]></parameter>
+  <parameter name="AUTO_FLASH_BRIDGE_ADDRESS_WIDTH" value="AddressWidth = 22" />
+  <parameter name="AUTO_GENERATION_ID" value="0" />
+  <parameter name="AUTO_GP_IRQ_INTERRUPTS_USED" value="0" />
+  <parameter name="AUTO_MAC_IRQ_INTERRUPTS_USED" value="1" />
+  <parameter name="AUTO_SLOW_BRIDGE_ADDRESS_MAP"><![CDATA[<address-map><slave name='openmac_0.pktBuf' start='0x0' end='0x4000' /><slave name='openmac_0.macReg' start='0x4000' end='0x6000' /><slave name='openmac_0.macTimer' start='0x6800' end='0x6820' /><slave name='sysid_qsys.control_slave' start='0x6A00' end='0x6A08' /><slave name='com_mem.s2' start='0x7000' end='0x8000' /></address-map>]]></parameter>
+  <parameter name="AUTO_SLOW_BRIDGE_ADDRESS_WIDTH" value="AddressWidth = 15" />
+  <parameter name="AUTO_SYNC_IRQ_INTERRUPTS_USED" value="1" />
+  <parameter name="AUTO_UNIQUE_ID" value="$${FILENAME}_pcp_0" />
+  <parameter name="cpu0_resetCpuBridge" value="cpu_bridge" />
+  <parameter name="tcmemSize" value="20480" />
  </module>
  <module
-   kind="altera_address_span_extender"
-   version="14.0"
-   enabled="1"
-   name="address_span_extender_flash_bridge">
-  <parameter name="DATA_WIDTH" value="32" />
-  <parameter name="MASTER_ADDRESS_WIDTH" value="27" />
-  <parameter name="SLAVE_ADDRESS_WIDTH" value="20" />
-  <parameter name="BURSTCOUNT_WIDTH" value="1" />
-  <parameter name="SUB_WINDOW_COUNT" value="1" />
-  <parameter name="MASTER_ADDRESS_DEF" value="4194304" />
-  <parameter name="TERMINATE_SLAVE_PORT" value="false" />
-  <parameter name="MAX_PENDING_READS" value="1" />
-  <parameter name="AUTO_CLOCK_CLOCK_RATE" value="50000000" />
-  <parameter name="AUTO_DEVICE_FAMILY" value="Cyclone V" />
+   name="sysid_qsys"
+   kind="altera_avalon_sysid_qsys"
+   version="16.1"
+   enabled="1">
+  <parameter name="id" value="-1395322092" />
  </module>
  <connection
-   kind="reset"
-   version="14.0"
-   start="clk_50.clk_reset"
-   end="clk_100.clk_in_reset" />
- <connection kind="clock" version="14.0" start="clk_50.clk" end="pcp_0.clk50" />
- <connection kind="clock" version="14.0" start="clk_100.clk" end="pcp_0.clk100" />
- <connection
-   kind="clock"
-   version="14.0"
-   start="clk_100.clk"
-   end="ddr3_emif_0.mp_cmd_clk_0" />
- <connection
-   kind="clock"
-   version="14.0"
-   start="clk_100.clk"
-   end="ddr3_emif_0.mp_rfifo_clk_0" />
- <connection
-   kind="clock"
-   version="14.0"
-   start="clk_100.clk"
-   end="ddr3_emif_0.mp_wfifo_clk_0" />
- <connection
-   kind="reset"
-   version="14.0"
-   start="clk_100.clk_reset"
-   end="ddr3_emif_0.mp_cmd_reset_n_0" />
- <connection
-   kind="reset"
-   version="14.0"
-   start="clk_50.clk_reset"
-   end="ddr3_emif_0.mp_cmd_reset_n_0" />
- <connection
-   kind="reset"
-   version="14.0"
-   start="clk_50.clk_reset"
-   end="ddr3_emif_0.mp_rfifo_reset_n_0" />
- <connection
-   kind="reset"
-   version="14.0"
-   start="clk_100.clk_reset"
-   end="ddr3_emif_0.mp_rfifo_reset_n_0" />
- <connection
-   kind="reset"
-   version="14.0"
-   start="clk_100.clk_reset"
-   end="ddr3_emif_0.mp_wfifo_reset_n_0" />
- <connection
-   kind="reset"
-   version="14.0"
-   start="clk_50.clk_reset"
-   end="ddr3_emif_0.mp_wfifo_reset_n_0" />
- <connection kind="clock" version="14.0" start="clk_50.clk" end="sysid_qsys.clk" />
- <connection
-   kind="reset"
-   version="14.0"
-   start="clk_50.clk_reset"
-   end="sysid_qsys.reset" />
- <connection
-   kind="reset"
-   version="14.0"
-   start="clk_100.clk_reset"
-   end="sysid_qsys.reset" />
- <connection
    kind="avalon"
-   version="14.0"
-   start="host_0.lw_bridge_m0"
-   end="sysid_qsys.control_slave">
-  <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x6a00" />
-  <parameter name="defaultConnection" value="false" />
- </connection>
- <connection kind="clock" version="14.0" start="clk_100.clk" end="host_0.clk100" />
- <connection kind="clock" version="14.0" start="clk_50.clk" end="host_0.clk50" />
- <connection
-   kind="reset"
-   version="14.0"
-   start="clk_50.clk_reset"
-   end="host_0.reset_clk50" />
- <connection
-   kind="reset"
-   version="14.0"
-   start="clk_100.clk_reset"
-   end="host_0.reset_clk50" />
- <connection
-   kind="reset"
-   version="14.0"
-   start="clk_50.clk_reset"
-   end="host_0.reset_clk100" />
- <connection
-   kind="reset"
-   version="14.0"
-   start="clk_100.clk_reset"
-   end="host_0.reset_clk100" />
- <connection
-   kind="clock"
-   version="14.0"
-   start="clk_50.clk"
-   end="openmac_0.mainClk" />
- <connection
-   kind="clock"
-   version="14.0"
-   start="clk_100.clk"
-   end="openmac_0.mainClkx2" />
- <connection
-   kind="clock"
-   version="14.0"
-   start="clk_100.clk"
-   end="openmac_0.dmaClk" />
- <connection kind="clock" version="14.0" start="clk_50.clk" end="openmac_0.pktClk" />
- <connection
-   kind="reset"
-   version="14.0"
-   start="clk_50.clk_reset"
-   end="openmac_0.mainRst" />
- <connection
-   kind="reset"
-   version="14.0"
-   start="clk_100.clk_reset"
-   end="openmac_0.mainRst" />
- <connection
-   kind="reset"
-   version="14.0"
-   start="clk_50.clk_reset"
-   end="openmac_0.dmaRst" />
- <connection
-   kind="reset"
-   version="14.0"
-   start="clk_100.clk_reset"
-   end="openmac_0.dmaRst" />
- <connection
-   kind="reset"
-   version="14.0"
-   start="clk_50.clk_reset"
-   end="openmac_0.pktRst" />
- <connection
-   kind="reset"
-   version="14.0"
-   start="clk_100.clk_reset"
-   end="openmac_0.pktRst" />
- <connection
-   kind="avalon"
-   version="14.0"
-   start="openmac_0.dma"
-   end="ddr3_emif_0.avl_0">
-  <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x0000" />
-  <parameter name="defaultConnection" value="false" />
- </connection>
- <connection
-   kind="interrupt"
-   version="14.0"
-   start="pcp_0.mac_irq"
-   end="openmac_0.macIrq">
-  <parameter name="irqNumber" value="0" />
- </connection>
- <connection
-   kind="interrupt"
-   version="14.0"
-   start="pcp_0.sync_irq"
-   end="openmac_0.timerIrq">
-  <parameter name="irqNumber" value="0" />
- </connection>
- <connection
-   kind="avalon"
-   version="14.0"
-   start="host_0.fpga_mem"
-   end="ddr3_emif_0.avl_0">
-  <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x0000" />
-  <parameter name="defaultConnection" value="false" />
- </connection>
- <connection
-   kind="avalon"
-   version="14.0"
-   start="host_0.lw_bridge_m0"
-   end="com_mem.s1">
-  <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x0000" />
-  <parameter name="defaultConnection" value="false" />
- </connection>
- <connection kind="clock" version="14.0" start="clk_50.clk" end="com_mem.clk1" />
- <connection kind="clock" version="14.0" start="clk_50.clk" end="com_mem.clk2" />
- <connection
-   kind="reset"
-   version="14.0"
-   start="clk_100.clk_reset"
-   end="com_mem.reset1" />
- <connection
-   kind="reset"
-   version="14.0"
-   start="clk_50.clk_reset"
-   end="com_mem.reset1" />
- <connection
-   kind="reset"
-   version="14.0"
-   start="clk_50.clk_reset"
-   end="com_mem.reset2" />
- <connection
-   kind="reset"
-   version="14.0"
-   start="clk_100.clk_reset"
-   end="com_mem.reset2" />
- <connection
-   kind="reset"
-   version="14.0"
-   start="clk_50.clk_reset"
-   end="pcp_0.rst_clk50" />
- <connection
-   kind="reset"
-   version="14.0"
-   start="clk_100.clk_reset"
-   end="pcp_0.rst_clk50" />
- <connection
-   kind="reset"
-   version="14.0"
-   start="clk_50.clk_reset"
-   end="pcp_0.rst_clk100" />
- <connection
-   kind="reset"
-   version="14.0"
-   start="clk_100.clk_reset"
-   end="pcp_0.rst_clk100" />
- <connection
-   kind="avalon"
-   version="14.0"
-   start="pcp_0.slow_bridge"
-   end="sysid_qsys.control_slave">
-  <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x6a00" />
-  <parameter name="defaultConnection" value="false" />
- </connection>
- <connection
-   kind="avalon"
-   version="14.0"
-   start="pcp_0.slow_bridge"
-   end="openmac_0.macReg">
-  <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x4000" />
-  <parameter name="defaultConnection" value="false" />
- </connection>
- <connection
-   kind="avalon"
-   version="14.0"
-   start="pcp_0.slow_bridge"
-   end="openmac_0.macTimer">
-  <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x6800" />
-  <parameter name="defaultConnection" value="false" />
- </connection>
- <connection
-   kind="avalon"
-   version="14.0"
-   start="pcp_0.slow_bridge"
-   end="openmac_0.pktBuf">
-  <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x0000" />
-  <parameter name="defaultConnection" value="false" />
- </connection>
- <connection
-   kind="avalon"
-   version="14.0"
+   version="16.1"
    start="pcp_0.cpu_bridge"
    end="address_span_extender_cpu_bridge.windowed_slave">
   <parameter name="arbitrationPriority" value="1" />
@@ -1005,7 +762,16 @@
  </connection>
  <connection
    kind="avalon"
-   version="14.0"
+   version="16.1"
+   start="openmac_0.dma"
+   end="ddr3_emif_0.avl_0">
+  <parameter name="arbitrationPriority" value="1" />
+  <parameter name="baseAddress" value="0x0000" />
+  <parameter name="defaultConnection" value="false" />
+ </connection>
+ <connection
+   kind="avalon"
+   version="16.1"
    start="address_span_extender_cpu_bridge.expanded_master"
    end="ddr3_emif_0.avl_0">
   <parameter name="arbitrationPriority" value="1" />
@@ -1013,47 +779,8 @@
   <parameter name="defaultConnection" value="false" />
  </connection>
  <connection
-   kind="clock"
-   version="14.0"
-   start="clk_100.clk"
-   end="address_span_extender_cpu_bridge.clock" />
- <connection
-   kind="reset"
-   version="14.0"
-   start="clk_50.clk_reset"
-   end="address_span_extender_cpu_bridge.reset" />
- <connection
-   kind="reset"
-   version="14.0"
-   start="clk_100.clk_reset"
-   end="address_span_extender_cpu_bridge.reset" />
- <connection
-   kind="clock"
-   version="14.0"
-   start="clk_50.clk"
-   end="address_span_extender_flash_bridge.clock" />
- <connection
-   kind="reset"
-   version="14.0"
-   start="clk_50.clk_reset"
-   end="address_span_extender_flash_bridge.reset" />
- <connection
-   kind="reset"
-   version="14.0"
-   start="clk_100.clk_reset"
-   end="address_span_extender_flash_bridge.reset" />
- <connection
    kind="avalon"
-   version="14.0"
-   start="pcp_0.flash_bridge"
-   end="address_span_extender_flash_bridge.windowed_slave">
-  <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x0000" />
-  <parameter name="defaultConnection" value="false" />
- </connection>
- <connection
-   kind="avalon"
-   version="14.0"
+   version="16.1"
    start="address_span_extender_flash_bridge.expanded_master"
    end="ddr3_emif_0.avl_0">
   <parameter name="arbitrationPriority" value="1" />
@@ -1062,21 +789,310 @@
  </connection>
  <connection
    kind="avalon"
-   version="14.0"
+   version="16.1"
+   start="pcp_0.flash_bridge"
+   end="address_span_extender_flash_bridge.windowed_slave">
+  <parameter name="arbitrationPriority" value="1" />
+  <parameter name="baseAddress" value="0x0000" />
+  <parameter name="defaultConnection" value="false" />
+ </connection>
+ <connection
+   kind="avalon"
+   version="16.1"
+   start="host_0.fpga_mem"
+   end="ddr3_emif_0.avl_0">
+  <parameter name="arbitrationPriority" value="1" />
+  <parameter name="baseAddress" value="0x0000" />
+  <parameter name="defaultConnection" value="false" />
+ </connection>
+ <connection
+   kind="avalon"
+   version="16.1"
+   start="host_0.lw_bridge_m0"
+   end="sysid_qsys.control_slave">
+  <parameter name="arbitrationPriority" value="1" />
+  <parameter name="baseAddress" value="0x6a00" />
+  <parameter name="defaultConnection" value="false" />
+ </connection>
+ <connection
+   kind="avalon"
+   version="16.1"
+   start="host_0.lw_bridge_m0"
+   end="com_mem.s1">
+  <parameter name="arbitrationPriority" value="1" />
+  <parameter name="baseAddress" value="0x0000" />
+  <parameter name="defaultConnection" value="false" />
+ </connection>
+ <connection
+   kind="avalon"
+   version="16.1"
+   start="pcp_0.slow_bridge"
+   end="sysid_qsys.control_slave">
+  <parameter name="arbitrationPriority" value="1" />
+  <parameter name="baseAddress" value="0x6a00" />
+  <parameter name="defaultConnection" value="false" />
+ </connection>
+ <connection
+   kind="avalon"
+   version="16.1"
+   start="pcp_0.slow_bridge"
+   end="openmac_0.macReg">
+  <parameter name="arbitrationPriority" value="1" />
+  <parameter name="baseAddress" value="0x4000" />
+  <parameter name="defaultConnection" value="false" />
+ </connection>
+ <connection
+   kind="avalon"
+   version="16.1"
+   start="pcp_0.slow_bridge"
+   end="openmac_0.macTimer">
+  <parameter name="arbitrationPriority" value="1" />
+  <parameter name="baseAddress" value="0x6800" />
+  <parameter name="defaultConnection" value="false" />
+ </connection>
+ <connection
+   kind="avalon"
+   version="16.1"
+   start="pcp_0.slow_bridge"
+   end="openmac_0.pktBuf">
+  <parameter name="arbitrationPriority" value="1" />
+  <parameter name="baseAddress" value="0x0000" />
+  <parameter name="defaultConnection" value="false" />
+ </connection>
+ <connection
+   kind="avalon"
+   version="16.1"
    start="pcp_0.slow_bridge"
    end="com_mem.s2">
   <parameter name="arbitrationPriority" value="1" />
   <parameter name="baseAddress" value="0x7000" />
   <parameter name="defaultConnection" value="false" />
  </connection>
+ <connection kind="clock" version="16.1" start="clk_50.clk" end="sysid_qsys.clk" />
+ <connection kind="clock" version="16.1" start="clk_50.clk" end="com_mem.clk1" />
+ <connection kind="clock" version="16.1" start="clk_100.clk" end="pcp_0.clk100" />
+ <connection kind="clock" version="16.1" start="clk_100.clk" end="host_0.clk100" />
+ <connection kind="clock" version="16.1" start="clk_50.clk" end="com_mem.clk2" />
+ <connection kind="clock" version="16.1" start="clk_50.clk" end="pcp_0.clk50" />
+ <connection kind="clock" version="16.1" start="clk_50.clk" end="host_0.clk50" />
+ <connection
+   kind="clock"
+   version="16.1"
+   start="clk_100.clk"
+   end="address_span_extender_cpu_bridge.clock" />
+ <connection
+   kind="clock"
+   version="16.1"
+   start="clk_50.clk"
+   end="address_span_extender_flash_bridge.clock" />
+ <connection
+   kind="clock"
+   version="16.1"
+   start="clk_100.clk"
+   end="openmac_0.dmaClk" />
+ <connection
+   kind="clock"
+   version="16.1"
+   start="clk_50.clk"
+   end="openmac_0.mainClk" />
+ <connection
+   kind="clock"
+   version="16.1"
+   start="clk_100.clk"
+   end="openmac_0.mainClkx2" />
+ <connection
+   kind="clock"
+   version="16.1"
+   start="clk_100.clk"
+   end="ddr3_emif_0.mp_cmd_clk_0" />
+ <connection
+   kind="clock"
+   version="16.1"
+   start="clk_100.clk"
+   end="ddr3_emif_0.mp_rfifo_clk_0" />
+ <connection
+   kind="clock"
+   version="16.1"
+   start="clk_100.clk"
+   end="ddr3_emif_0.mp_wfifo_clk_0" />
+ <connection kind="clock" version="16.1" start="clk_50.clk" end="openmac_0.pktClk" />
  <connection
    kind="interrupt"
-   version="14.0"
+   version="16.1"
    start="host_0.hostif_irq_i"
    end="openmac_0.timerPulse">
   <parameter name="irqNumber" value="0" />
  </connection>
+ <connection
+   kind="interrupt"
+   version="16.1"
+   start="pcp_0.mac_irq"
+   end="openmac_0.macIrq">
+  <parameter name="irqNumber" value="0" />
+ </connection>
+ <connection
+   kind="interrupt"
+   version="16.1"
+   start="pcp_0.sync_irq"
+   end="openmac_0.timerIrq">
+  <parameter name="irqNumber" value="0" />
+ </connection>
+ <connection
+   kind="reset"
+   version="16.1"
+   start="clk_50.clk_reset"
+   end="clk_100.clk_in_reset" />
+ <connection
+   kind="reset"
+   version="16.1"
+   start="clk_50.clk_reset"
+   end="openmac_0.dmaRst" />
+ <connection
+   kind="reset"
+   version="16.1"
+   start="clk_100.clk_reset"
+   end="openmac_0.dmaRst" />
+ <connection
+   kind="reset"
+   version="16.1"
+   start="clk_50.clk_reset"
+   end="openmac_0.mainRst" />
+ <connection
+   kind="reset"
+   version="16.1"
+   start="clk_100.clk_reset"
+   end="openmac_0.mainRst" />
+ <connection
+   kind="reset"
+   version="16.1"
+   start="clk_100.clk_reset"
+   end="ddr3_emif_0.mp_cmd_reset_n_0" />
+ <connection
+   kind="reset"
+   version="16.1"
+   start="clk_50.clk_reset"
+   end="ddr3_emif_0.mp_cmd_reset_n_0" />
+ <connection
+   kind="reset"
+   version="16.1"
+   start="clk_50.clk_reset"
+   end="ddr3_emif_0.mp_rfifo_reset_n_0" />
+ <connection
+   kind="reset"
+   version="16.1"
+   start="clk_100.clk_reset"
+   end="ddr3_emif_0.mp_rfifo_reset_n_0" />
+ <connection
+   kind="reset"
+   version="16.1"
+   start="clk_100.clk_reset"
+   end="ddr3_emif_0.mp_wfifo_reset_n_0" />
+ <connection
+   kind="reset"
+   version="16.1"
+   start="clk_50.clk_reset"
+   end="ddr3_emif_0.mp_wfifo_reset_n_0" />
+ <connection
+   kind="reset"
+   version="16.1"
+   start="clk_50.clk_reset"
+   end="openmac_0.pktRst" />
+ <connection
+   kind="reset"
+   version="16.1"
+   start="clk_100.clk_reset"
+   end="openmac_0.pktRst" />
+ <connection
+   kind="reset"
+   version="16.1"
+   start="clk_50.clk_reset"
+   end="sysid_qsys.reset" />
+ <connection
+   kind="reset"
+   version="16.1"
+   start="clk_100.clk_reset"
+   end="sysid_qsys.reset" />
+ <connection
+   kind="reset"
+   version="16.1"
+   start="clk_50.clk_reset"
+   end="address_span_extender_cpu_bridge.reset" />
+ <connection
+   kind="reset"
+   version="16.1"
+   start="clk_100.clk_reset"
+   end="address_span_extender_cpu_bridge.reset" />
+ <connection
+   kind="reset"
+   version="16.1"
+   start="clk_50.clk_reset"
+   end="address_span_extender_flash_bridge.reset" />
+ <connection
+   kind="reset"
+   version="16.1"
+   start="clk_100.clk_reset"
+   end="address_span_extender_flash_bridge.reset" />
+ <connection
+   kind="reset"
+   version="16.1"
+   start="clk_100.clk_reset"
+   end="com_mem.reset1" />
+ <connection
+   kind="reset"
+   version="16.1"
+   start="clk_50.clk_reset"
+   end="com_mem.reset1" />
+ <connection
+   kind="reset"
+   version="16.1"
+   start="clk_50.clk_reset"
+   end="com_mem.reset2" />
+ <connection
+   kind="reset"
+   version="16.1"
+   start="clk_100.clk_reset"
+   end="com_mem.reset2" />
+ <connection
+   kind="reset"
+   version="16.1"
+   start="clk_50.clk_reset"
+   end="host_0.reset_clk100" />
+ <connection
+   kind="reset"
+   version="16.1"
+   start="clk_100.clk_reset"
+   end="host_0.reset_clk100" />
+ <connection
+   kind="reset"
+   version="16.1"
+   start="clk_50.clk_reset"
+   end="host_0.reset_clk50" />
+ <connection
+   kind="reset"
+   version="16.1"
+   start="clk_100.clk_reset"
+   end="host_0.reset_clk50" />
+ <connection
+   kind="reset"
+   version="16.1"
+   start="clk_50.clk_reset"
+   end="pcp_0.rst_clk100" />
+ <connection
+   kind="reset"
+   version="16.1"
+   start="clk_100.clk_reset"
+   end="pcp_0.rst_clk100" />
+ <connection
+   kind="reset"
+   version="16.1"
+   start="clk_50.clk_reset"
+   end="pcp_0.rst_clk50" />
+ <connection
+   kind="reset"
+   version="16.1"
+   start="clk_100.clk_reset"
+   end="pcp_0.rst_clk50" />
  <interconnectRequirement for="$system" name="qsys_mm.clockCrossingAdapter" value="HANDSHAKE" />
- <interconnectRequirement for="$system" name="qsys_mm.maxAdditionalLatency" value="1" />
  <interconnectRequirement for="$system" name="qsys_mm.insertDefaultSlave" value="false" />
+ <interconnectRequirement for="$system" name="qsys_mm.maxAdditionalLatency" value="1" />
 </system>

--- a/hardware/boards/altera-c5soc/mn-soc-shmem-gpio/quartus/toplevel.vhd
+++ b/hardware/boards/altera-c5soc/mn-soc-shmem-gpio/quartus/toplevel.vhd
@@ -285,8 +285,8 @@ architecture rtl of toplevel is
             ddr3_emif_0_pll_sharing_pll_addr_cmd_clk            : out   std_logic;
             ddr3_emif_0_pll_sharing_pll_avl_clk                 : out   std_logic;
             ddr3_emif_0_pll_sharing_pll_config_clk              : out   std_logic;
-            ddr3_emif_0_pll_sharing_pll_dr_clk                  : out   std_logic;
-            ddr3_emif_0_pll_sharing_pll_dr_clk_pre_phy_clk      : out   std_logic;
+            --ddr3_emif_0_pll_sharing_pll_dr_clk                  : out   std_logic;
+            --ddr3_emif_0_pll_sharing_pll_dr_clk_pre_phy_clk      : out   std_logic;
             ddr3_emif_0_pll_sharing_pll_mem_phy_clk             : out   std_logic;
             ddr3_emif_0_pll_sharing_afi_phy_clk                 : out   std_logic;
             ddr3_emif_0_pll_sharing_pll_avl_phy_clk             : out   std_logic;

--- a/stack/proj/generic/liboplkmnapp-dualprocshm/configure-c5socarm.cmake
+++ b/stack/proj/generic/liboplkmnapp-dualprocshm/configure-c5socarm.cmake
@@ -77,7 +77,7 @@ INCLUDE_DIRECTORIES(
 # Set additional target specific compile flags
 SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${ALT_HOST_CFLAGS} -fmessage-length=0 -ffunction-sections -fdata-sections -fno-inline")
 
-ADD_DEFINITIONS(-D__C5SOC__ -D__ALTERA_ARM__)
+ADD_DEFINITIONS(-D__C5SOC__ -D__ALTERA_ARM__ -Dsoc_cv_av)
 ################################################################################
 
 

--- a/stack/src/arch/altera-c5socarm/sleep.c
+++ b/stack/src/arch/altera-c5socarm/sleep.c
@@ -147,8 +147,8 @@ int msleep(unsigned long milliSeconds_p)
 {
     uint64_t            startTickStamp = alt_globaltmr_get64();
     uint64_t            waitTickCount = getTimerTicksFromScaled(ALT_GPT_CPU_GLOBAL_TMR, SECS_TO_MILLISECS, milliSeconds_p);
-    volatile uint32_t*  pGlbTimerRegCntBaseLow = (volatile uint32_t*)(GLOBALTMR_BASE + GLOBALTMR_CNTR_LO_REG_OFFSET);
-    volatile uint32_t*  pGlbTimerRegCntBaseHigh = (volatile uint32_t*)(GLOBALTMR_BASE + GLOBALTMR_CNTR_HI_REG_OFFSET);
+    volatile uint32_t*  pGlbTimerRegCntBaseLow = (volatile uint32_t*)(ALT_GLOBALTMR_BASE + ALT_GLOBALTMR_CNTR_LO_REG_OFFSET);
+    volatile uint32_t*  pGlbTimerRegCntBaseHigh = (volatile uint32_t*)(ALT_GLOBALTMR_BASE + ALT_GLOBALTMR_CNTR_HI_REG_OFFSET);
     uint64_t            curTickStamp = 0;
     uint32_t            temp = 0;
     uint32_t            hi = 0;


### PR DESCRIPTION
In casse the openPowerlink-projects decides to switch to more recent versions of the altera development tolls / quartus one day, this could patch could be used to get an idea what changes were nescessary for us in order to get it working with Quartus-16.1 (although with a custom board, so the excact configuration shipped has not been tested).