### PR TITLE
[FEATURE] Add SoC time stamp forwarding feature in BSD semaphore design

### DIFF
--- a/stack/include/common/timesync.h
+++ b/stack/include/common/timesync.h
@@ -8,6 +8,7 @@
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -44,6 +45,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // const defines
 //------------------------------------------------------------------------------
 #define TIMESYNC_SYNC_BSDSEM            "/semTimeSyncSync"
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+#define TIMESYNC_TIMESTAMP_SHM          "/shmTimeSyncTimestamp"
+#endif
 
 //------------------------------------------------------------------------------
 // typedef

--- a/stack/src/kernel/timesync/timesynckcal-bsdsem.c
+++ b/stack/src/kernel/timesync/timesynckcal-bsdsem.c
@@ -5,7 +5,8 @@
 \brief  CAL kernel timesync module using BSD semaphores
 
 This file contains an implementation for the kernel CAL timesync module which
-uses BSD semaphores for synchronization.
+uses BSD semaphores for synchronization and a shared memory (shm) to transfer
+time stamps.
 
 The sync module is responsible to synchronize the user layer.
 
@@ -14,6 +15,7 @@ The sync module is responsible to synchronize the user layer.
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -50,6 +52,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <sys/stat.h>
 #include <semaphore.h>
 
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
+
 //============================================================================//
 //            G L O B A L   D E F I N I T I O N S                             //
 //============================================================================//
@@ -66,7 +73,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // global function prototypes
 //------------------------------------------------------------------------------
 
-
 //============================================================================//
 //            P R I V A T E   D E F I N I T I O N S                           //
 //============================================================================//
@@ -78,15 +84,34 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //------------------------------------------------------------------------------
 // local types
 //------------------------------------------------------------------------------
+/**
+\brief Memory instance for kernel timesync module
+
+This structure contains all necessary information needed by the timesync CAL
+module for BSD semaphores.
+*/
+typedef struct
+{
+    sem_t*                    syncSem;                   ///< Semaphore for synchronization between kernel and user tiemsync modules.
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+    OPLK_FILE_HANDLE          fd;                        ///< File descriptor for POWERLINK device.
+    size_t                    memSize;                   ///< Memory size of SoC timestamp shared memory.
+    tTimesyncSharedMemory*    pSharedMemory;             ///< Pointer to SoC timestamp shared memory.
+#endif
+}tTimesynckcalInstance;
 
 //------------------------------------------------------------------------------
 // local vars
 //------------------------------------------------------------------------------
-static sem_t*           syncSem_l;
+static tTimesynckcalInstance instance_l;
 
 //------------------------------------------------------------------------------
 // local function prototypes
 //------------------------------------------------------------------------------
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+static tOplkError createTimestampShm(void);
+static tOplkError destroyTimestampShm(void);
+#endif
 
 //============================================================================//
 //            P U B L I C   F U N C T I O N S                                 //
@@ -105,14 +130,31 @@ The function initializes the kernel CAL timesync module.
 //------------------------------------------------------------------------------
 tOplkError timesynckcal_init(void)
 {
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+    tOplkError  ret;
+#endif
+
+    OPLK_MEMSET(&instance_l, 0, sizeof(tTimesynckcalInstance));
     sem_unlink(TIMESYNC_SYNC_BSDSEM);
 
-    syncSem_l = sem_open(TIMESYNC_SYNC_BSDSEM, O_CREAT, S_IRWXG, 1);
-    if (syncSem_l == SEM_FAILED)
+    instance_l.syncSem = sem_open(TIMESYNC_SYNC_BSDSEM, O_CREAT, S_IRWXG, 1);
+    if (instance_l.syncSem == SEM_FAILED)
     {
         DEBUG_LVL_ERROR_TRACE("%s() creating sem failed!\n", __func__);
         return kErrorNoResource;
     }
+
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+    ret = createTimestampShm();
+    if (ret != kErrorOk)
+    {
+        // Close the semaphore
+        sem_close(instance_l.syncSem);
+        // Unlink the semaphore
+        sem_unlink(TIMESYNC_SYNC_BSDSEM);
+        return ret;
+    }
+#endif
 
     return kErrorOk;
 }
@@ -128,7 +170,17 @@ The function cleans up the CAL timesync module
 //------------------------------------------------------------------------------
 void timesynckcal_exit(void)
 {
-    sem_close(syncSem_l);
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+    tOplkError ret;
+
+    ret = destroyTimestampShm();
+    if (ret != kErrorOk)
+    {
+        DEBUG_LVL_ERROR_TRACE("%s() timesync shared memory exit failed", __func__);
+    }
+#endif
+
+    sem_close(instance_l.syncSem);
     sem_unlink(TIMESYNC_SYNC_BSDSEM);
 }
 
@@ -145,7 +197,7 @@ The function sends a sync event.
 //------------------------------------------------------------------------------
 tOplkError timesynckcal_sendSyncEvent(void)
 {
-    sem_post(syncSem_l);
+    sem_post(instance_l.syncSem);
 
     return kErrorOk;
 }
@@ -184,15 +236,100 @@ The function returns the reference to the timesync shared memory.
 //------------------------------------------------------------------------------
 tTimesyncSharedMemory* timesynckcal_getSharedMemory(void)
 {
-    // Not implemented yet
-    return NULL;
+    return instance_l.pSharedMemory;
 }
-#endif
 
 //============================================================================//
 //            P R I V A T E   F U N C T I O N S                               //
 //============================================================================//
 /// \name Private Functions
 /// \{
+
+//------------------------------------------------------------------------------
+/**
+\brief  Create timesync shared memory
+
+This function initializes and allocates the shared memory for SoC timestamp.
+
+\return The function returns a tOplkError error code.
+*/
+//------------------------------------------------------------------------------
+static tOplkError createTimestampShm(void)
+{
+    instance_l.memSize = sizeof(tTimesyncSharedMemory);
+
+    // Initialize shared memory for SoC timestamp
+    instance_l.fd = shm_open(TIMESYNC_TIMESTAMP_SHM, O_CREAT | O_RDWR, 0);
+
+    if (instance_l.fd < 0)
+    {
+        DEBUG_LVL_ERROR_TRACE("%s() Initialization of shared memory failed!\n",
+                              __func__);
+        return kErrorNoResource;
+    }
+
+    // Allocate shared memory for SoC timestamp
+    if (ftruncate(instance_l.fd, instance_l.memSize) < 0)
+    {
+        DEBUG_LVL_ERROR_TRACE("%s() Allocation of shared memory failed!\n",
+                              __func__);
+        // Unlink the timesync shared memory
+        shm_unlink(TIMESYNC_TIMESTAMP_SHM);
+        return kErrorNoResource;
+    }
+
+    instance_l.pSharedMemory = (void*)mmap(NULL,
+                                           instance_l.memSize,     // Memory size
+                                           PROT_READ | PROT_WRITE, // Map as read and write memory
+                                           MAP_SHARED,             // Map as shared memory
+                                           instance_l.fd,          // File descriptor for POWERLINK device
+                                           0);
+
+    // Check for valid memory mapping
+    if (instance_l.pSharedMemory == MAP_FAILED)
+    {
+        DEBUG_LVL_ERROR_TRACE("%s() timesync shared memory mmap failed!\n",
+                              __func__);
+        instance_l.pSharedMemory = NULL;
+        //Unlink the timesync shared memory
+        shm_unlink(TIMESYNC_TIMESTAMP_SHM);
+        return kErrorNoResource;
+    }
+
+    return kErrorOk;
+}
+
+//------------------------------------------------------------------------------
+/**
+\brief  Destroy timesync shared memory
+
+This function unmaps and unlinks the SoC timestamp shared memory.
+
+\return The function returns a tOplkError error code.
+*/
+//------------------------------------------------------------------------------
+static tOplkError destroyTimestampShm(void)
+{
+    if (instance_l.pSharedMemory != NULL)
+    {
+        // Unmap timesync shared memory
+        if (munmap(instance_l.pSharedMemory, instance_l.memSize) != 0)
+        {
+            DEBUG_LVL_ERROR_TRACE("%s() timesync shared memory munmap failed!\n",
+                                  __func__);
+
+            return kErrorNoResource;
+        }
+
+        instance_l.pSharedMemory = NULL;
+        instance_l.memSize = 0;
+    }
+
+    // Unlink timesync shared memory
+    shm_unlink(TIMESYNC_TIMESTAMP_SHM);
+
+    return kErrorOk;
+}
+#endif
 
 /// \}

--- a/stack/src/user/timesync/timesyncucal-bsdsem.c
+++ b/stack/src/user/timesync/timesyncucal-bsdsem.c
@@ -5,13 +5,15 @@
 \brief  Sync implementation for the user CAL timesync module using BSD semaphores
 
 This file contains a sync implementation for the user CAL timesync module. It
-uses BSD semaphores for synchronisation.
+uses BSD semaphores for synchronization and a shared memory (shm) to transfer
+time stamps.
 
 \ingroup module_timesyncucal
 *******************************************************************************/
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -50,6 +52,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <semaphore.h>
 #include <time.h>
 
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+#include <sys/mman.h>
+#endif
+
 //============================================================================//
 //            G L O B A L   D E F I N I T I O N S                             //
 //============================================================================//
@@ -66,7 +72,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // global function prototypes
 //------------------------------------------------------------------------------
 
-
 //============================================================================//
 //            P R I V A T E   D E F I N I T I O N S                           //
 //============================================================================//
@@ -78,15 +83,34 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //------------------------------------------------------------------------------
 // local types
 //------------------------------------------------------------------------------
+/**
+\brief Memory instance for user timesync module
+
+This structure contains all necessary information needed by the timesync CAL
+module for BSD semaphores.
+*/
+typedef struct
+{
+    sem_t*                    syncSem;                   ///< Semaphore for synchronization between kernel and user tiemsync modules
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+    OPLK_FILE_HANDLE          fd;                        ///< File descriptor for POWERLINK device
+    size_t                    memSize;                   ///< Memory size of SoC timestamp shared memory
+    tTimesyncSharedMemory*    pSharedMemory;             ///< Pointer to SoC timestamp shared memory
+#endif
+}tTimesyncucalInstance;
 
 //------------------------------------------------------------------------------
 // local vars
 //------------------------------------------------------------------------------
-static sem_t*           syncSem_l;
+static tTimesyncucalInstance instance_l;
 
 //------------------------------------------------------------------------------
 // local function prototypes
 //------------------------------------------------------------------------------
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+static tOplkError createTimestampShm(void);
+static tOplkError destroyTimestampShm(void);
+#endif
 
 //============================================================================//
 //            P U B L I C   F U N C T I O N S                                 //
@@ -107,14 +131,31 @@ The function initializes the user CAL timesync module
 //------------------------------------------------------------------------------
 tOplkError timesyncucal_init(tSyncCb pfnSyncCb_p)
 {
-    UNUSED_PARAMETER(pfnSyncCb_p);
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+    tOplkError  ret;
+#endif
 
-    syncSem_l = sem_open(TIMESYNC_SYNC_BSDSEM, O_CREAT, S_IRWXG, 1);
-    if (syncSem_l == SEM_FAILED)
+    UNUSED_PARAMETER(pfnSyncCb_p);
+    OPLK_MEMSET(&instance_l, 0, sizeof(tTimesyncucalInstance));
+
+    instance_l.syncSem = sem_open(TIMESYNC_SYNC_BSDSEM, O_CREAT, S_IRWXG, 1);
+    if (instance_l.syncSem == SEM_FAILED)
     {
         DEBUG_LVL_ERROR_TRACE("%s() creating sem failed!\n", __func__);
         return kErrorNoResource;
     }
+
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+    ret = createTimestampShm();
+    if (ret != kErrorOk)
+    {
+        // Close the semaphore
+        sem_close(instance_l.syncSem);
+        // Unlink the semaphore
+        sem_unlink(TIMESYNC_SYNC_BSDSEM);
+        return ret;
+    }
+#endif
 
     return kErrorOk;
 }
@@ -130,7 +171,18 @@ The function cleans up the user CAL timesync module
 //------------------------------------------------------------------------------
 void timesyncucal_exit(void)
 {
-    sem_close(syncSem_l);
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+    tOplkError ret;
+
+    ret = destroyTimestampShm();
+    if (ret != kErrorOk)
+    {
+        DEBUG_LVL_ERROR_TRACE("%s() exit failed", __func__);
+    }
+#endif
+
+    sem_close(instance_l.syncSem);
+
 }
 
 //------------------------------------------------------------------------------
@@ -169,11 +221,11 @@ tOplkError timesyncucal_waitSyncEvent(ULONG timeout_p)
         }
         clock_gettime(CLOCK_REALTIME, &currentTime);
         TIMESPECADD(&semTimeout, &currentTime);
-        semRet = sem_timedwait(syncSem_l, &semTimeout);
+        semRet = sem_timedwait(instance_l.syncSem, &semTimeout);
     }
     else
     {
-        semRet = sem_wait(syncSem_l);
+        semRet = sem_wait(instance_l.syncSem);
     }
 
     if (semRet == 0)
@@ -182,10 +234,103 @@ tOplkError timesyncucal_waitSyncEvent(ULONG timeout_p)
         return kErrorGeneralError;
 }
 
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+//------------------------------------------------------------------------------
+/**
+\brief  Get timesync shared memory
+
+The function returns the reference to the timesync shared memory.
+
+\return The function returns a pointer to the timesync shared memory.
+
+\ingroup module_timesyncucal
+*/
+//------------------------------------------------------------------------------
+tTimesyncSharedMemory* timesyncucal_getSharedMemory(void)
+{
+    return instance_l.pSharedMemory;
+}
+
 //============================================================================//
 //            P R I V A T E   F U N C T I O N S                               //
 //============================================================================//
 /// \name Private Functions
 /// \{
+
+//------------------------------------------------------------------------------
+/**
+\brief  Create timesync shared memory
+
+This function initializes and allocates the shared memory for SoC timestamp.
+
+\return The function returns a tOplkError error code.
+*/
+//------------------------------------------------------------------------------
+static tOplkError createTimestampShm(void)
+{
+    instance_l.memSize = sizeof(tTimesyncSharedMemory);
+
+    // Initialize shared memory for SOC timestamp
+    instance_l.fd = shm_open(TIMESYNC_TIMESTAMP_SHM, O_RDWR, 0);
+
+    if (instance_l.fd < 0)
+    {
+        DEBUG_LVL_ERROR_TRACE("%s() Initialization of shared memory failed!\n",
+                              __func__);
+        return kErrorNoResource;
+    }
+
+    instance_l.pSharedMemory = (void*)mmap(NULL,
+                                           instance_l.memSize,     // Memory size
+                                           PROT_READ | PROT_WRITE, // Map as read and write memory
+                                           MAP_SHARED,             // Map as shared memory
+                                           instance_l.fd,          // File descriptor for POWERLINK device
+                                           0);
+
+    // Check for valid memory mapping
+    if (instance_l.pSharedMemory == MAP_FAILED)
+    {
+        DEBUG_LVL_ERROR_TRACE("%s() timesync shared memory mmap failed!\n",
+                              __func__);
+        instance_l.pSharedMemory = NULL;
+        //Unlink timesync shared memory
+        shm_unlink(TIMESYNC_TIMESTAMP_SHM);
+        return kErrorNoResource;
+    }
+
+    return kErrorOk;
+}
+
+//------------------------------------------------------------------------------
+/**
+\brief  Destroy timesync shared memory
+
+This function unmaps and unlinks the SoC timestamp shared memory.
+
+\return The function returns a tOplkError error code.
+*/
+//------------------------------------------------------------------------------
+static tOplkError destroyTimestampShm(void)
+{
+    // Unmap timesync shared memory
+    if (instance_l.pSharedMemory != NULL)
+    {
+        if (munmap(instance_l.pSharedMemory, instance_l.memSize) != 0)
+        {
+            DEBUG_LVL_ERROR_TRACE("%s() timesync shared memory munmap failed!\n",
+                                  __func__);
+            return kErrorNoResource;
+        }
+
+        instance_l.pSharedMemory = NULL;
+        instance_l.memSize = 0;
+    }
+
+    // Unlink timesync shared memory
+    shm_unlink(TIMESYNC_TIMESTAMP_SHM);
+
+    return kErrorOk;
+}
+#endif
 
 /// \}


### PR DESCRIPTION
 - Create a shared memory between kernel and user layer to store SoC
   timestamps using mmap.
 - The initialized shared memory is un-mapped during the exit of the
   function.

Change-Id: Ia1e0926db05520ea7bf7e12c4a801d05e54c4fa9

This pull request includes the changes requested from #229