### PR TITLE
[FEATURE] Add SoC timestamp forwarding for Linux ioctl design

### DIFF
--- a/drivers/linux/drv_kernelmod_edrv/main.c
+++ b/drivers/linux/drv_kernelmod_edrv/main.c
@@ -11,6 +11,7 @@ the openPOWERLINK kernel stack.
 *******************************************************************************/
 /*------------------------------------------------------------------------------
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -554,7 +555,10 @@ The function implements openPOWERLINK kernel module mmap function.
 static int powerlinkMmap(struct file* pFile_p,
                          struct vm_area_struct* pVmArea_p)
 {
-    BYTE*       pPdoMem;
+    BYTE*                        pPdoMem;
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+    tTimesyncSharedMemory*       pSocTimeMem;
+#endif
     tOplkError  ret = kErrorOk;
 
     UNUSED_PARAMETER(pFile_p);
@@ -567,24 +571,52 @@ static int powerlinkMmap(struct file* pFile_p,
 
     pVmArea_p->vm_flags |= VM_RESERVED;
     pVmArea_p->vm_ops = &powerlinkVmOps_l;
-
-    ret = pdokcal_getPdoMemRegion(&pPdoMem, NULL);
-
-    if ((ret != kErrorOk) || (pPdoMem == NULL))
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+    if (pVmArea_p->vm_pgoff == 0)
     {
-        DEBUG_LVL_ERROR_TRACE("%s() no PDO memory allocated!\n", __func__);
-        return -ENOMEM;
-    }
+#endif
+        ret = pdokcal_getPdoMemRegion(&pPdoMem, NULL);
 
-    if (remap_pfn_range(pVmArea_p,
-                        pVmArea_p->vm_start,
-                        (__pa(pPdoMem) >> PAGE_SHIFT),
-                        pVmArea_p->vm_end - pVmArea_p->vm_start,
-                        pVmArea_p->vm_page_prot))
-    {
-        DEBUG_LVL_ERROR_TRACE("%s() remap_pfn_range failed\n", __func__);
-        return -EAGAIN;
+        if ((ret != kErrorOk) || (pPdoMem == NULL))
+        {
+            DEBUG_LVL_ERROR_TRACE("%s() no PDO memory allocated!\n", __func__);
+            return -ENOMEM;
+        }
+
+        if (remap_pfn_range(pVmArea_p,
+                            pVmArea_p->vm_start,
+                            (__pa(pPdoMem) >> PAGE_SHIFT),
+                            pVmArea_p->vm_end - pVmArea_p->vm_start,
+                            pVmArea_p->vm_page_prot))
+        {
+            DEBUG_LVL_ERROR_TRACE("%s() remap_pfn_range failed for PDO memory\n",
+                                  __func__);
+            return -EAGAIN;
+        }
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
     }
+    else
+    {
+        pSocTimeMem = timesynckcal_getSharedMemory();
+        if (pSocTimeMem == NULL)
+        {
+            DEBUG_LVL_ERROR_TRACE("%s() no timesync memory allocated!\n", __func__);
+            return -ENOMEM;
+        }
+
+        if (remap_pfn_range(pVmArea_p,
+                            pVmArea_p->vm_start,
+                            (__pa(pSocTimeMem) >> PAGE_SHIFT),
+                            pVmArea_p->vm_end - pVmArea_p->vm_start,
+                            pVmArea_p->vm_page_prot))
+        {
+            DEBUG_LVL_ERROR_TRACE("%s() remap_pfn_range failed for timesync memory\n",
+                                  __func__);
+            return -EAGAIN;
+        }
+
+    }
+#endif
 
     powerlinkVmaOpen(pVmArea_p);
 

--- a/stack/src/kernel/timesync/timesynckcal-linuxkernel.c
+++ b/stack/src/kernel/timesync/timesynckcal-linuxkernel.c
@@ -5,7 +5,9 @@
 \brief  CAL kernel timesync module using the openPOWERLINK Linux kernel driver
 
 This file contains an implementation for the kernel CAL timesync module which
-uses the openPOWERLINK Linux kernel driver interface.
+uses the openPOWERLINK Linux kernel driver interface. In addition SoC timestamp
+forwarding feature implementation is done by creating a shared memory for the
+user and kernel.
 
 The sync module is responsible to synchronize the user layer.
 
@@ -14,6 +16,7 @@ The sync module is responsible to synchronize the user layer.
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -77,11 +80,21 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //------------------------------------------------------------------------------
 // local types
 //------------------------------------------------------------------------------
+/**
+\brief Instance for kernel timesync module
+
+This structure contains all necessary information needed by the timesync CAL
+module for Linux kernel module.
+*/
 typedef struct
 {
-    wait_queue_head_t       syncWaitQueue;
-    BOOL                    fSync;
-    BOOL                    fInitialized;
+    wait_queue_head_t       syncWaitQueue;   ///< Wait queue for time sync event
+    BOOL                    fSync;           ///< Flag for wait sync event
+    BOOL                    fInitialized;    ///< Flag for timesynckcal module initialization
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+    tTimesyncSharedMemory*  pSharedMemory;   ///< Shared timesync structure
+    size_t                  memSize;         ///< Size of the timesync shared memory
+#endif
 } tTimesynckCalInstance;
 
 //------------------------------------------------------------------------------
@@ -92,6 +105,10 @@ static tTimesynckCalInstance instance_l; ///< Instance variable of kernel timesy
 //------------------------------------------------------------------------------
 // local function prototypes
 //------------------------------------------------------------------------------
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+static tOplkError allocateSocMem(void** ppSocMem_p, size_t memSize_p);
+static tOplkError freeSocMem(void* pMem_p, size_t memSize_p);
+#endif
 
 //============================================================================//
 //            P U B L I C   F U N C T I O N S                                 //
@@ -110,10 +127,25 @@ The function initializes the kernel CAL timesync module.
 //------------------------------------------------------------------------------
 tOplkError timesynckcal_init(void)
 {
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+    void*  pMem;
+#endif
+
     OPLK_MEMSET(&instance_l, 0, sizeof(tTimesynckCalInstance));
 
     init_waitqueue_head(&instance_l.syncWaitQueue);
     instance_l.fInitialized = TRUE;
+
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+    instance_l.memSize = sizeof(tTimesyncSharedMemory);
+    if (instance_l.pSharedMemory != NULL)
+        freeSocMem(instance_l.pSharedMemory, instance_l.memSize);
+
+    if (allocateSocMem(&pMem, instance_l.memSize) != kErrorOk)
+        return kErrorNoResource;
+
+    instance_l.pSharedMemory = (tTimesyncSharedMemory*)pMem;
+#endif
 
     return kErrorOk;
 }
@@ -130,6 +162,13 @@ The function cleans up the CAL timesync module
 void timesynckcal_exit(void)
 {
     instance_l.fInitialized = FALSE;
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+    if (instance_l.pSharedMemory != NULL)
+       {
+            freeSocMem(instance_l.pSharedMemory, instance_l.memSize);
+            instance_l.pSharedMemory = NULL;
+       }
+#endif
 }
 
 //------------------------------------------------------------------------------
@@ -218,10 +257,8 @@ The function returns the reference to the timesync shared memory.
 //------------------------------------------------------------------------------
 tTimesyncSharedMemory* timesynckcal_getSharedMemory(void)
 {
-    // Not implemented yet
-    return NULL;
+    return instance_l.pSharedMemory;
 }
-#endif
 
 //============================================================================//
 //            P R I V A T E   F U N C T I O N S                               //
@@ -229,4 +266,62 @@ tTimesyncSharedMemory* timesynckcal_getSharedMemory(void)
 /// \name Private Functions
 /// \{
 
+//------------------------------------------------------------------------------
+/**
+\brief  Free timesync shared memory
+
+The function frees shared memory which was allocated in the kernel layer for
+transferring the SoC timestamp.
+
+\param[in,out]  pMem_p              Pointer to the shared memory base
+\param[in]      memSize_p           Size of timesync shared memory
+
+\return The function returns a tOplkError error code.
+*/
+//------------------------------------------------------------------------------
+static tOplkError freeSocMem(void* pMem_p, size_t memSize_p)
+{
+    ULONG   order;
+
+    // Check parameter validity
+    ASSERT(pMem_p != NULL);
+
+    order = get_order(memSize_p);
+    free_pages((ULONG)pMem_p, order);
+
+    return kErrorOk;
+}
+
+//------------------------------------------------------------------------------
+/**
+\brief  Allocate timesync shared memory
+
+The function allocates shared memory required to transfer the SoC timestamp from
+the kernel layer to the user layer.
+
+\param[out]     ppSocMem_p          Pointer to store the timesync shared memory base address.
+\param[in]      memSize_p           Size of timesync shared memory
+
+\return The function returns a tOplkError error code.
+*/
+//------------------------------------------------------------------------------
+static tOplkError allocateSocMem(void** ppSocMem_p, size_t memSize_p)
+{
+    ULONG   order;
+
+    // Check parameter validity
+    ASSERT(ppSocMem_p != NULL);
+
+    order = get_order(memSize_p);
+    *ppSocMem_p = (void*)__get_free_pages(GFP_KERNEL, order);
+    if (*ppSocMem_p == NULL)
+    {
+        DEBUG_LVL_ERROR_TRACE("%s() Memory for SoC could not be created\n",
+                              __func__);
+        return kErrorNoResource;
+    }
+
+    return kErrorOk;
+}
+#endif
 /// \}

--- a/stack/src/user/timesync/timesyncucal-ioctl.c
+++ b/stack/src/user/timesync/timesyncucal-ioctl.c
@@ -5,13 +5,16 @@
 \brief  Sync implementation for the user CAL timesync module using Linux ioctl
 
 This file contains a sync implementation for the user CAL timesync module. It
-uses a Linux ioctl call for synchronisation.
+uses a Linux ioctl call for synchronisation. In addition SoC timestamp
+forwarding feature implementation is done by creating a shared memory for the
+user and kernel.
 
 \ingroup module_timesyncucal
 *******************************************************************************/
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -50,6 +53,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <sys/ioctl.h>
 #include <time.h>
 
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+#include <unistd.h>
+#include <sys/mman.h>
+#endif
+
 //============================================================================//
 //            G L O B A L   D E F I N I T I O N S                             //
 //============================================================================//
@@ -66,7 +74,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // global function prototypes
 //------------------------------------------------------------------------------
 
-
 //============================================================================//
 //            P R I V A T E   D E F I N I T I O N S                           //
 //============================================================================//
@@ -78,15 +85,33 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //------------------------------------------------------------------------------
 // local types
 //------------------------------------------------------------------------------
+/**
+\brief Instance for user timesync module
+
+This structure contains all necessary information needed by the timesync user
+CAL module for Linux ioctl design.
+*/
+typedef struct
+{
+    OPLK_FILE_HANDLE        fd;               ///< File descriptor
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+    tTimesyncSharedMemory*  pSharedMemory;    ///< Shared timesync structure
+    size_t                  memSize;          ///< Size of the timesync shared memory
+#endif
+}tTimesynckcalInstance;
 
 //------------------------------------------------------------------------------
 // local vars
 //------------------------------------------------------------------------------
-static OPLK_FILE_HANDLE fd_l;
+static tTimesynckcalInstance instance_l;
 
 //------------------------------------------------------------------------------
 // local function prototypes
 //------------------------------------------------------------------------------
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+static tOplkError getTimeSyncSharedMem(void);
+static tOplkError releaseTimeSyncSharedMem(void);
+#endif
 
 //============================================================================//
 //            P U B L I C   F U N C T I O N S                                 //
@@ -109,8 +134,16 @@ tOplkError timesyncucal_init(tSyncCb pfnSyncCb_p)
 {
     UNUSED_PARAMETER(pfnSyncCb_p);
 
-    fd_l = ctrlucal_getFd();
-
+    instance_l.fd = ctrlucal_getFd();
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+    instance_l.memSize = sizeof(tTimesyncSharedMemory);
+    if (getTimeSyncSharedMem() != kErrorOk)
+    {
+        DEBUG_LVL_ERROR_TRACE("%s() Could not get timesync shared memory\n",
+                              __func__);
+        return kErrorNoResource;
+    }
+#endif
     return kErrorOk;
 }
 
@@ -125,7 +158,16 @@ The function cleans up the user CAL timesync module
 //------------------------------------------------------------------------------
 void timesyncucal_exit(void)
 {
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+    tOplkError ret;
 
+    ret = releaseTimeSyncSharedMem();
+    if (ret != kErrorOk)
+    {
+        DEBUG_LVL_ERROR_TRACE("%s() SoC Timestamp shm could not be released\n",
+                              __func__);
+    }
+#endif
 }
 
 //------------------------------------------------------------------------------
@@ -148,11 +190,28 @@ tOplkError timesyncucal_waitSyncEvent(ULONG timeout_p)
 {
     int ret;
 
-    ret = ioctl(fd_l, PLK_CMD_TIMESYNC_SYNC, timeout_p);
+    ret = ioctl(instance_l.fd, PLK_CMD_TIMESYNC_SYNC, timeout_p);
     if (ret == 0)
         return kErrorOk;
 
     return kErrorGeneralError;
+}
+
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+//------------------------------------------------------------------------------
+/**
+\brief  Get timesync shared memory
+
+The function returns the reference to the timesync shared memory base.
+
+\return The function returns a pointer to the timesync shared memory base.
+
+\ingroup module_timesyncucal
+*/
+//------------------------------------------------------------------------------
+tTimesyncSharedMemory* timesyncucal_getSharedMemory(void)
+{
+    return instance_l.pSharedMemory;
 }
 
 //============================================================================//
@@ -160,5 +219,65 @@ tOplkError timesyncucal_waitSyncEvent(ULONG timeout_p)
 //============================================================================//
 /// \name Private Functions
 /// \{
+
+//------------------------------------------------------------------------------
+/**
+\brief  Get timesync shared memory
+
+The function remaps the timesync shared memory into user space memory using the
+mmap function.
+
+\return The function returns a tOplkError error code.
+\retval kErrorOk                    mmap successful
+\retval kErrorNoResource            mmap failed
+*/
+//------------------------------------------------------------------------------
+static tOplkError getTimeSyncSharedMem(void)
+{
+    instance_l.pSharedMemory = mmap(NULL,                                   // Map at any address in vma
+                                    instance_l.memSize + 2 * sysconf(_SC_PAGE_SIZE),
+                                    PROT_READ | PROT_WRITE,                 // Map as read and write memory
+                                    MAP_SHARED,                             // Map as shared memory
+                                    instance_l.fd,                          // File descriptor
+                                    sysconf(_SC_PAGE_SIZE));
+
+    if (instance_l.pSharedMemory == MAP_FAILED)
+    {
+        DEBUG_LVL_ERROR_TRACE("%s() mmap failed!\n", __func__);
+        instance_l.pSharedMemory = NULL;
+        return kErrorNoResource;
+    }
+
+    return kErrorOk;
+}
+
+//------------------------------------------------------------------------------
+/**
+\brief  Release timesync shared memory
+
+The function releases the remapped timesync shared memory into user memory.
+
+\return The function returns a tOplkError error code.
+\retval kErrorOk                    munmap successful
+\retval kErrorGeneralError          munmap failed
+*/
+//------------------------------------------------------------------------------
+static tOplkError releaseTimeSyncSharedMem(void)
+{
+    if (instance_l.pSharedMemory != NULL)
+    {
+        if (munmap(instance_l.pSharedMemory, instance_l.memSize) != 0)
+        {
+            DEBUG_LVL_ERROR_TRACE("%s() munmap failed\n", __func__);
+            return kErrorNoResource;
+        }
+
+        instance_l.pSharedMemory = NULL;
+        instance_l.memSize = 0;
+    }
+
+    return kErrorOk;
+}
+#endif
 
 /// \}


### PR DESCRIPTION
 - Allocate memory for SoC timestamp in kernel layer.
 - Extend the mmap function in kernel main to support remapping
   non PDO memory.
 - Update the timesync ioctl user cal to map the SoC timestamp memory
   in kernel layer into user space using mmap function.

Change-Id: I0fd3b6bc81defb6c3418b605c7bbb1af5f38aaac

This pull request incorporates the comments from previous pull request #230 