### PR TITLE
[FEATURE] Add MN net time distribution feature in Linux designs

### DIFF
--- a/stack/include/common/timesync.h
+++ b/stack/include/common/timesync.h
@@ -8,6 +8,7 @@
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -87,7 +88,8 @@ transfer time information from the kernel to the user layer.
 */
 typedef struct
 {
-    tTimesyncSocTimeTripleBuf   socTime;    ///< Buffer to transfer SoC time
+    tTimesyncSocTimeTripleBuf   kernelToUserSocTime;    ///< Buffer to transfer SoC time from kernel to user
+    tTimesyncSocTimeTripleBuf   userToKernelSocTime;    ///< Buffer to transfer net time from user to kernel
 } tTimesyncSharedMemory;
 
 #endif /* _INC_common_timesync_H_ */

--- a/stack/include/kernel/timesynck.h
+++ b/stack/include/kernel/timesynck.h
@@ -8,6 +8,7 @@
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -67,6 +68,7 @@ tOplkError timesynck_process(const tEvent* pEvent_p);
 #if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
 tOplkError timesynck_setSocTime(const tTimesyncSocTime* pSocTime_p);
 #endif /* defined(CONFIG_INCLUDE_SOC_TIME_FORWARD) */
+tOplkError timesynck_getNetTime(tNetTime* netTime, BOOL* pNewData_p);
 
 #ifdef __cplusplus
 }

--- a/stack/include/user/timesyncu.h
+++ b/stack/include/user/timesyncu.h
@@ -8,6 +8,7 @@
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -60,6 +61,7 @@ extern "C"
 tOplkError timesyncu_init(tSyncCb pfnSyncCb_p);
 void       timesyncu_exit(void);
 tOplkError timesyncu_getSocTime(tOplkApiSocTimeInfo* pSocTime_p);
+void       timesyncu_setNetTime(void);
 
 #ifdef __cplusplus
 }

--- a/stack/src/kernel/timesync/timesynck.c
+++ b/stack/src/kernel/timesync/timesynck.c
@@ -11,6 +11,7 @@ This file contains the main implementation of the kernel timesync module.
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -129,9 +130,9 @@ tOplkError timesynck_init(void)
     OPLK_MEMSET(timesynckInstance_l.pSharedMemory, 0, sizeof(*timesynckInstance_l.pSharedMemory));
 
     // Initialize triple buffer
-    timesynckInstance_l.pSharedMemory->socTime.clean = 0;
-    timesynckInstance_l.pSharedMemory->socTime.read = 1;
-    timesynckInstance_l.pSharedMemory->socTime.write = 2;
+    timesynckInstance_l.pSharedMemory->kernelToUserSocTime.clean = 0;
+    timesynckInstance_l.pSharedMemory->kernelToUserSocTime.read = 1;
+    timesynckInstance_l.pSharedMemory->kernelToUserSocTime.write = 2;
 
     OPLK_DCACHE_FLUSH(timesynckInstance_l.pSharedMemory, sizeof(*timesynckInstance_l.pSharedMemory));
 #endif
@@ -285,7 +286,7 @@ tOplkError timesynck_setSocTime(const tTimesyncSocTime* pSocTime_p)
         return kErrorNoResource;
     }
 
-    pTripleBuf = &timesynckInstance_l.pSharedMemory->socTime;
+    pTripleBuf = &timesynckInstance_l.pSharedMemory->kernelToUserSocTime;
 
     OPLK_DCACHE_INVALIDATE(pTripleBuf, sizeof(*pTripleBuf));
 
@@ -304,6 +305,52 @@ tOplkError timesynck_setSocTime(const tTimesyncSocTime* pSocTime_p)
 
     return kErrorOk;
 }
+
+#if defined(CONFIG_INCLUDE_NMT_MN)
+//------------------------------------------------------------------------------
+/**
+\brief  Get net time
+
+The function gets the net time set by the timesyncu module.
+
+\param[in]      netTime_p          Pointer to NETTIME time information structure
+\param[in]      pNewData_p         Pointer to store the net time flag
+
+\return The function returns a tOplkError error code.
+
+\ingroup module_timesynck
+*/
+//------------------------------------------------------------------------------
+tOplkError timesynck_getNetTime(tNetTime* netTime_p, BOOL* pNewData_p)
+{
+    OPLK_ATOMIC_T readBuf;
+
+    if (timesynckInstance_l.pSharedMemory->userToKernelSocTime.newData)
+    {
+        *pNewData_p = TRUE;
+        readBuf = timesynckInstance_l.pSharedMemory->userToKernelSocTime.read;
+
+        OPLK_ATOMIC_EXCHANGE(&timesynckInstance_l.pSharedMemory->userToKernelSocTime.clean,
+                             readBuf,
+                             timesynckInstance_l.pSharedMemory->userToKernelSocTime.read);
+        timesynckInstance_l.pSharedMemory->userToKernelSocTime.newData = 0;
+
+        // Flush data cache for variables changed in this function
+        OPLK_DCACHE_FLUSH(&(timesynckInstance_l.pSharedMemory->userToKernelSocTime.read),
+                          sizeof(OPLK_ATOMIC_T));
+        OPLK_DCACHE_FLUSH(&(timesynckInstance_l.pSharedMemory->userToKernelSocTime.newData),
+                          sizeof(UINT8));
+
+        netTime_p->nsec = (timesynckInstance_l.pSharedMemory->userToKernelSocTime.aTripleBuf[0].netTime.nsec);
+        netTime_p->sec = (timesynckInstance_l.pSharedMemory->userToKernelSocTime.aTripleBuf[0].netTime.sec);
+    }
+    else
+        *pNewData_p = FALSE;
+
+    return kErrorOk;
+}
+#endif
+
 #endif
 
 //============================================================================//

--- a/stack/src/user/timesync/timesyncucal-bsdsem.c
+++ b/stack/src/user/timesync/timesyncucal-bsdsem.c
@@ -12,6 +12,7 @@ uses BSD semaphores for synchronisation.
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -43,6 +44,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <common/oplkinc.h>
 #include <common/timesync.h>
 #include <user/timesyncucal.h>
+#include <user/timesyncu.h>
 
 #include <errno.h>
 #include <fcntl.h>
@@ -83,6 +85,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // local vars
 //------------------------------------------------------------------------------
 static sem_t*           syncSem_l;
+#if defined(CONFIG_INCLUDE_NMT_MN)
+static BOOL             fFirstSyncEvent = FALSE;
+#endif
 
 //------------------------------------------------------------------------------
 // local function prototypes
@@ -177,7 +182,17 @@ tOplkError timesyncucal_waitSyncEvent(ULONG timeout_p)
     }
 
     if (semRet == 0)
+    {
+#if defined(CONFIG_INCLUDE_NMT_MN)
+        if (fFirstSyncEvent != TRUE)
+        {   // Set MN net time at first sync event
+            timesyncu_setNetTime();
+            fFirstSyncEvent = TRUE;
+        }
+#endif
+
         return kErrorOk;
+    }
     else
         return kErrorGeneralError;
 }


### PR DESCRIPTION
 - Add a shared buffer in tTimesyncSharedMemory structure to transfer the net
   time from user layer to kerenl layer for distributing to the network.
 - Rename the socTime buffer as kernelToUserSocTime in tTimesyncSharedMemory
   structure.
 - Set the net time at the first sync event in user layer and copy the net time
   in userToKernelSocTime buffer.
 - Get the net time value in kernel from userToKernelSocTime buffer and forward
   it back to the user layer using kernelToUserSocTime buffer to synchronize
   with the world time.

Change-Id: I854a6056bc0093920190cbadcd50525b84ba1630