### PR TITLE
[FEATURE] Add SoC time stamp forwarding feature in Zynq Hybrid design

### DIFF
--- a/drivers/linux/drv_kernelmod_zynq/CMakeLists.txt
+++ b/drivers/linux/drv_kernelmod_zynq/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 # Copyright (c) 2013, SYSTEC electronik GmbH
 # Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
-# Copyright (c) 2016, Kalycito Infotech Private Limited
+# Copyright (c) 2017, Kalycito Infotech Private Limited
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -152,7 +152,7 @@ SET(MODULE_SOURCE_FILES
     ${COMMON_SOURCE_DIR}/debugstr.c
     ${CONTRIB_SOURCE_DIR}/trace/trace-printk.c
     ${KERNEL_SOURCE_DIR}/timesync/timesynck.c
-    ${KERNEL_SOURCE_DIR}/timesync/timesynckcal-linuxkernel.c
+    ${KERNEL_SOURCE_DIR}/timesync/timesynckcal-linuxdpshm.c
     ${KERNEL_SOURCE_DIR}/veth/veth-linuxpcie.c
     ${ARCH_SOURCE_DIR}/target-linuxkernel.c
     )

--- a/drivers/linux/drv_kernelmod_zynq/drvintf-dualprocshm.c
+++ b/drivers/linux/drv_kernelmod_zynq/drvintf-dualprocshm.c
@@ -16,7 +16,7 @@ provide direct access to user application for specific shared memory regions.
 *******************************************************************************/
 
 /*------------------------------------------------------------------------------
-Copyright (c) 2016, Kalycito Infotech Private Limited
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -78,6 +78,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // TODO:Get the following value from configuration header files
 #define DUALPROCSHM_BUFF_ID_ERRHDLR     12
 #define DUALPROCSHM_BUFF_ID_PDO         13
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+#define DUALPROCSHM_BUFF_ID_TIMESYNC    14
+#endif
 
 //------------------------------------------------------------------------------
 // global function prototypes
@@ -112,6 +115,9 @@ typedef struct
     tCircBufInstance*       apEventQueueInst[kEventQueueNum];   ///< Event queue instances.
     tCircBufInstance*       apDllQueueInst[DRV_DLLCALTXQUEUE_INSTCNT]; ///< DLL queue instances.
     tErrHndObjects*         pErrorObjects;                      ///< Pointer to error objects.
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+    tTimesyncSharedMemory*  pTimesyncShm;                       ///< Pointer to timesync shared memory
+#endif
     BOOL                    fDriverActive;                      ///< Flag to identify status of driver interface.
 #if defined(CONFIG_INCLUDE_VETH)
     BOOL                    fVEthActive;                        ///< Flag to indicate whether the VEth interface is intialized.
@@ -913,6 +919,11 @@ Maps the kernel layer memory specified by the caller into user layer.
 \param[in]      size_p              Size of the memory to be mapped.
 
 \return Returns tOplkError error code.
+\retval kErrorOk                   Kernel layer memory to user layer memory
+                                   mapping is successful
+\retval kErrorNoResource           Kernel to User memory mapping is not successful
+\retval kErrorInvalidInstanceParam PCP buffer pointer lies outside the shared
+                                   memory region
 
 \ingroup module_driver_linux_kernel_zynq
 */
@@ -969,21 +980,36 @@ tOplkError drvintf_mapKernelMem(const void* pKernelMem_p,
         drvIntfInstance_l.shmSize = remoteProcSharedMemInst.span;
     }
 
-    if ((ULONG)pKernelMem_p <= drvIntfInstance_l.shmMemRemote)
-    {
-        DEBUG_LVL_ERROR_TRACE("%s() Error: PCP buffer pointer lies outside the shared memory region\n");
-        return kErrorInvalidInstanceParam;
-    }
-    else
+    if (((ULONG)pKernelMem_p <= (drvIntfInstance_l.shmMemRemote + drvIntfInstance_l.shmSize)) &&
+        (ULONG)pKernelMem_p >= drvIntfInstance_l.shmMemRemote)
     {
         *ppUserMem_p = (void*)((ULONG)pKernelMem_p -
                                (ULONG)drvIntfInstance_l.shmMemRemote +
                                (ULONG)drvIntfInstance_l.shmMemLocal);
-        DEBUG_LVL_DRVINTF_TRACE("LA: 0x%lX, RA: 0x%lX, KA: 0x%lX, UA: 0x%lX\n",
+        DEBUG_LVL_DRVINTF_TRACE("LA: 0x%lX, RA: 0x%lX, KA: 0x%lX, UA: 0x%p\n",
                                 drvIntfInstance_l.shmMemLocal,
                                 drvIntfInstance_l.shmMemRemote,
                                 (ULONG)pKernelMem_p,
                                 (ULONG)(*ppUserMem_p));
+    }
+    else
+    {
+        // Checks whether the passed memory is a local memory
+        if (((ULONG)pKernelMem_p <= (drvIntfInstance_l.shmMemLocal + drvIntfInstance_l.shmSize)) &&
+            (ULONG)pKernelMem_p >= drvIntfInstance_l.shmMemLocal)
+        {
+            *ppUserMem_p = (void*)((ULONG)pKernelMem_p);
+             DEBUG_LVL_DRVINTF_TRACE("LA: 0x%lX, RA: 0x%lX, KA: 0x%lX, UA: 0x%p\n",
+                                     drvIntfInstance_l.shmMemLocal,
+                                     drvIntfInstance_l.shmMemRemote,
+                                     (ULONG)pKernelMem_p,
+                                     (ULONG)(*ppUserMem_p));
+        }
+        else
+        {
+            DEBUG_LVL_ERROR_TRACE("%s() Error: PCP buffer pointer lies outside the shared memory region\n");
+            return kErrorInvalidInstanceParam;
+        }
     }
 
     return kErrorOk;
@@ -1079,6 +1105,119 @@ ULONG drvintf_getFileBufferSize(void)
 {
     return CONFIG_CTRL_FILE_CHUNK_SIZE;
 }
+
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+//------------------------------------------------------------------------------
+/**
+\brief  Initialize timesync shared memory
+
+This function retrieves the shared memory for the timesync module. This memory
+is accessible to user space through ioctl calls.
+
+\return The function returns a tOplkError error code.
+\retval kErrorOk               Successful timesync shared memory initialization
+\retval kErrorInvalidOperation Initialization not possible because driver is not
+                               active
+\retval kErrorNoResource       Failed to get shared memory from dualprocshm
+
+\ingroup module_driver_linux_kernel_zynq
+*/
+//------------------------------------------------------------------------------
+tOplkError drvintf_initTimesyncShm(void)
+{
+    tDualprocReturn dualRet;
+    void*           pBase;
+    size_t          span;
+
+    if (!drvIntfInstance_l.fDriverActive || (drvIntfInstance_l.pTimesyncShm != NULL))
+    {
+        DEBUG_LVL_ERROR_TRACE("%s(): Driver is not active or timesync shared memory buffer is not empty\n",
+                              __func__);
+        return kErrorInvalidOperation;
+    }
+
+    dualRet = dualprocshm_getMemory(drvIntfInstance_l.dualProcDrvInst, // Driver instance
+                                    DUALPROCSHM_BUFF_ID_TIMESYNC,      // ID of timesync memory buffer
+                                    &pBase,                            // Base address of the requested memory
+                                    &span,                             // Size of the memory to be allocated
+                                    FALSE);                            // Retrieves address from address mapping table
+    if (dualRet != kDualprocSuccessful)
+    {
+        DEBUG_LVL_ERROR_TRACE("%s(): Couldn't get timesync shared memory buffer (0x%X)\n",
+                              __func__,
+                              dualRet);
+        return kErrorNoResource;
+    }
+
+    if (span < sizeof(tTimesyncSharedMemory))
+    {
+        DEBUG_LVL_ERROR_TRACE("%s(): Timesync shared memory buffer too small\n",
+                              __func__);
+        return kErrorNoResource;
+    }
+
+    drvIntfInstance_l.pTimesyncShm = (tTimesyncSharedMemory*)pBase;
+
+    return kErrorOk;
+}
+
+//------------------------------------------------------------------------------
+/**
+\brief  Free timesync shared memory
+
+Frees the timesync shared memory.
+
+\return The function returns a tOplkError error code.
+\retval kErrorOk    Exit drvintf timesync shared memory successful
+
+\ingroup module_driver_linux_kernel_zynq
+*/
+//------------------------------------------------------------------------------
+tOplkError drvintf_exitTimesyncShm(void)
+{
+    tOplkError ret;
+
+    if (drvIntfInstance_l.pTimesyncShm != NULL)
+    {
+        ret = dualprocshm_freeMemory(drvIntfInstance_l.dualProcDrvInst, // Driver instance
+                                     DUALPROCSHM_BUFF_ID_TIMESYNC,      // ID of timesync memory buffer
+                                     FALSE);                            // Clear address from address mapping table
+        if (ret != kDualprocSuccessful)
+        {
+            DEBUG_LVL_ERROR_TRACE("%s(): The dynamic memory buffer is not freed successfully\n",
+                                  __func__);
+        }
+
+        drvIntfInstance_l.pTimesyncShm = NULL;
+    }
+
+    return kErrorOk;
+}
+
+//------------------------------------------------------------------------------
+/**
+\brief  Get timesync shared memory
+
+This routine fetches the address of timesync shared memory to be passed to user
+layer.
+
+\return The function returns a pointer to the timesync shared memory.
+
+\ingroup module_driver_linux_kernel_zynq
+*/
+//------------------------------------------------------------------------------
+tTimesyncSharedMemory* drvintf_getTimesyncShm(void)
+{
+    if (!drvIntfInstance_l.fDriverActive)
+    {
+        DEBUG_LVL_ERROR_TRACE("%s(): Driver is not active and timesync shared memory is not available\n",
+                              __func__);
+        return NULL;
+    }
+
+    return drvIntfInstance_l.pTimesyncShm;
+}
+#endif
 
 //============================================================================//
 //            P R I V A T E   F U N C T I O N S                               //

--- a/drivers/linux/drv_kernelmod_zynq/drvintf.h
+++ b/drivers/linux/drv_kernelmod_zynq/drvintf.h
@@ -9,7 +9,7 @@ openPOWERLINK Zynq Linux driver interface to PCP - Header file
 *******************************************************************************/
 
 /*------------------------------------------------------------------------------
-Copyright (c) 2016, Kalycito Infotech Private Limited
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -45,6 +45,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <common/ctrlcal-mem.h>
 #include <common/dllcal.h>
 
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+#include <common/timesync.h>
+#endif
+
 //------------------------------------------------------------------------------
 // const defines
 //------------------------------------------------------------------------------
@@ -73,41 +77,46 @@ typedef tOplkError (*tDrvIntfCbVeth)(const tFrameInfo* pFrameInfo_p);
 extern "C"
 {
 #endif
-tOplkError drvintf_init(void);
-void       drvintf_exit(void);
-tOplkError drvintf_executeCmd(tCtrlCmd* ctrlCmd_p);
-tOplkError drvintf_waitSyncEvent(void);
-tOplkError drvintf_readInitParam(tCtrlInitParam* pInitParam_p);
-tOplkError drvintf_storeInitParam(const tCtrlInitParam* pInitParam_p);
-tOplkError drvintf_getStatus(UINT16* pStatus_p);
-tOplkError drvintf_getHeartbeat(UINT16* pHeartbeat_p);
+tOplkError             drvintf_init(void);
+void                   drvintf_exit(void);
+tOplkError             drvintf_executeCmd(tCtrlCmd* ctrlCmd_p);
+tOplkError             drvintf_waitSyncEvent(void);
+tOplkError             drvintf_readInitParam(tCtrlInitParam* pInitParam_p);
+tOplkError             drvintf_storeInitParam(const tCtrlInitParam* pInitParam_p);
+tOplkError             drvintf_getStatus(UINT16* pStatus_p);
+tOplkError             drvintf_getHeartbeat(UINT16* pHeartbeat_p);
 #if defined(CONFIG_INCLUDE_VETH)
-tOplkError drvintf_regVethHandler(tDrvIntfCbVeth pfnDrvIntfCbVeth_p);
-tOplkError drvintf_sendVethFrame(const tFrameInfo* pFrameInfo_p);
+tOplkError             drvintf_regVethHandler(tDrvIntfCbVeth pfnDrvIntfCbVeth_p);
+tOplkError             drvintf_sendVethFrame(const tFrameInfo* pFrameInfo_p);
 #endif
-tOplkError drvintf_sendAsyncFrame(tDllCalQueue queue_p,
-                                  size_t size_p,
-                                  const void* pData_p);
-tOplkError drvintf_writeErrorObject(UINT32 offset_p,
-                                    UINT32 errVal_p);
-tOplkError drvintf_readErrorObject(UINT32 offset_p,
-                                   UINT32* pErrVal_p);
-tOplkError drvintf_postEvent(const tEvent* pEvent_p);
-tOplkError drvintf_getEvent(tEvent* pK2UEvent_p,
-                            size_t* pSize_p);
-tOplkError drvintf_getPdoMem(void** ppPdoMem_p,
-                             size_t* pMemSize_p);
-tOplkError drvintf_freePdoMem(void** ppPdoMem_p,
-                              size_t memSize_p);
-tOplkError drvintf_getBenchmarkMem(void** ppBenchmarkMem_p);
-tOplkError drvintf_freeBenchmarkMem(void** ppBenchmarkMem_p);
-tOplkError drvintf_mapKernelMem(const void* pKernelMem_p,
-                                void** ppUserMem_p,
-                                size_t size_p);
-void       drvintf_unmapKernelMem(void** ppUserMem_p);
-tOplkError drvintf_writeFileBuffer(const tOplkApiFileChunkDesc* pDesc_p,
-                                   const void* pBuf_p);
-ULONG      drvintf_getFileBufferSize(void);
+tOplkError             drvintf_sendAsyncFrame(tDllCalQueue queue_p,
+                                              size_t size_p,
+                                              const void* pData_p);
+tOplkError             drvintf_writeErrorObject(UINT32 offset_p,
+                                                UINT32 errVal_p);
+tOplkError             drvintf_readErrorObject(UINT32 offset_p,
+                                               UINT32* pErrVal_p);
+tOplkError             drvintf_postEvent(const tEvent* pEvent_p);
+tOplkError             drvintf_getEvent(tEvent* pK2UEvent_p,
+                                        size_t* pSize_p);
+tOplkError             drvintf_getPdoMem(void** ppPdoMem_p,
+                                         size_t* pMemSize_p);
+tOplkError             drvintf_freePdoMem(void** ppPdoMem_p,
+                                          size_t memSize_p);
+tOplkError             drvintf_getBenchmarkMem(void** ppBenchmarkMem_p);
+tOplkError             drvintf_freeBenchmarkMem(void** ppBenchmarkMem_p);
+tOplkError             drvintf_mapKernelMem(const void* pKernelMem_p,
+                                            void** ppUserMem_p,
+                                            size_t size_p);
+void                   drvintf_unmapKernelMem(void** ppUserMem_p);
+tOplkError             drvintf_writeFileBuffer(const tOplkApiFileChunkDesc* pDesc_p,
+                                               const void* pBuf_p);
+ULONG                  drvintf_getFileBufferSize(void);
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+tOplkError             drvintf_initTimesyncShm(void);
+tOplkError             drvintf_exitTimesyncShm(void);
+tTimesyncSharedMemory* drvintf_getTimesyncShm(void);
+#endif
 
 #ifdef __cplusplus
 }

--- a/drivers/linux/drv_kernelmod_zynq/main.c
+++ b/drivers/linux/drv_kernelmod_zynq/main.c
@@ -176,6 +176,9 @@ static int          getEventForUser(unsigned long arg_p);
 static int          postEventFromUser(unsigned long arg_p);
 static int          writeFileBuffer(unsigned long arg_p);
 static int          getFileBufferSize(unsigned long arg_p);
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+static int          getSocTimestampAddress(unsigned long arg_p);
+#endif
 
 //------------------------------------------------------------------------------
 //  Kernel module specific data structures
@@ -580,6 +583,12 @@ static int plkIntfIoctl(struct inode* pInode_p,
         case PLK_CMD_CTRL_GET_FILE_BUFFER_SIZE:
             ret = getFileBufferSize(arg_p);
             break;
+
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+        case PLK_CMD_TIMESYNC_MAP_OFFSET:
+            ret = getSocTimestampAddress(arg_p);
+            break;
+#endif
 
         default:
             DEBUG_LVL_ERROR_TRACE("PLK: - Invalid command (cmd=%d type=%d)\n",
@@ -1165,5 +1174,36 @@ static int getFileBufferSize(unsigned long arg_p)
 
     return ret;
 }
+
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+//------------------------------------------------------------------------------
+/**
+\brief  Get timesync SoC timestamp kernel address
+
+The function implements the ioctl for getting the timesync shared memory pointer.
+
+\param[in]      arg_p               Pointer to the timesync shared memory argument
+                                    passed by the ioctl interface.
+
+\return The function returns Linux error code.
+*/
+//------------------------------------------------------------------------------
+static int getSocTimestampAddress(unsigned long arg_p)
+{
+    tTimesyncSharedMemory* pSharedMemory;
+
+    // Gets the kernel address of timesync shared memory from timesync kernel CAL
+    pSharedMemory = timesynckcal_getSharedMemory();
+
+    if (pSharedMemory == NULL)
+        return -ENXIO;
+
+    // Copy the received kernel address to timesync user CAL
+    if (copy_to_user((void __user*)arg_p, &pSharedMemory, sizeof(ULONG)))
+        return -EFAULT;
+
+    return 0;
+}
+#endif
 
 /// \}

--- a/stack/cmake/stackfiles.cmake
+++ b/stack/cmake/stackfiles.cmake
@@ -4,7 +4,7 @@
 #
 # Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
 # Copyright (c) 2016, Franz Profelt (franz.profelt@gmail.com)
-# Copyright (c) 2016, Kalycito Infotech Private Limited
+# Copyright (c) 2017, Kalycito Infotech Private Limited
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -281,7 +281,7 @@ SET(PDO_UCAL_LINUXMMAPIOCTL_SOURCES
     )
 
 SET(PDO_UCAL_LINUXPCIE_SOURCES
-    ${USER_SOURCE_DIR}/timesync/timesyncucal-ioctl.c
+    ${USER_SOURCE_DIR}/timesync/timesyncucal-linuxdpshm.c
     ${USER_SOURCE_DIR}/pdo/pdoucalmem-linuxpcie.c
     )
 
@@ -441,7 +441,7 @@ SET(PDO_KCAL_POSIXMEM_SOURCES
 
 SET(PDO_KCAL_LINUXKERNEL_SOURCES
     ${KERNEL_SOURCE_DIR}/pdo/pdokcalmem-linuxkernel.c
-    ${KERNEL_SOURCE_DIR}/timesync/timesynckcal-linuxkernel.c
+    ${KERNEL_SOURCE_DIR}/timesync/timesynckcal-linuxdpshm.c
     )
 
 SET(PDO_KCAL_LINUXKERNEL_SOURCES

--- a/stack/include/common/driver-linuxpcie.h
+++ b/stack/include/common/driver-linuxpcie.h
@@ -10,7 +10,7 @@ PCIe driver interface for Linux kernel.
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
-Copyright (c) 2015, Kalycito Infotech Private Limited
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -68,6 +68,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define PLK_CMD_PDO_MAP_OFFSET                  _IOR (PLK_IOC_MAGIC, 11, ULONG)
 #define PLK_CMD_CTRL_WRITE_FILE_BUFFER          _IOW (PLK_IOC_MAGIC, 12, tIoctlFileChunk)
 #define PLK_CMD_CTRL_GET_FILE_BUFFER_SIZE       _IOR (PLK_IOC_MAGIC, 13, ULONG)
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+#define PLK_CMD_TIMESYNC_MAP_OFFSET             _IOWR(PLK_IOC_MAGIC, 14, ULONG)
+#endif
 
 //------------------------------------------------------------------------------
 // typedef

--- a/stack/src/common/memmap/memmap-linuxpcie.c
+++ b/stack/src/common/memmap/memmap-linuxpcie.c
@@ -12,7 +12,7 @@ for Linux systems using openPOWERLINK PCIe driver.
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2015, Kalycito Infotech Private Limited.
-Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2017, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -174,11 +174,11 @@ void* memmap_mapKernelBuffer(const void* pKernelBuffer_p, UINT bufferSize_p)
     memmapInstance_l.offset = (ULONG)pKernelBuffer_p &
                               (sysconf(_SC_PAGE_SIZE) - 1);
 
-    memmapInstance_l.pUserBuf = mmap(NULL,          // Map at any address in vma
+    memmapInstance_l.pUserBuf = mmap(NULL,                       // Map at any address in vma
                                      memmapInstance_l.memSize + 2 * sysconf(_SC_PAGE_SIZE),
-                                     PROT_READ,     // Map as read only memory
-                                     MAP_SHARED,    // Map as shared memory, $$ private is enough for us
-                                     fd_l,          // file descriptor
+                                     PROT_READ | PROT_WRITE,     // Map as read and write memory
+                                     MAP_SHARED,                 // Map as shared memory, $$ private is enough for us
+                                     fd_l,                       // file descriptor
                                      (ULONG)memmapInstance_l.pKernelBuf);
     if (memmapInstance_l.pUserBuf == MAP_FAILED)
     {

--- a/stack/src/kernel/timesync/timesynckcal-linuxdpshm.c
+++ b/stack/src/kernel/timesync/timesynckcal-linuxdpshm.c
@@ -1,0 +1,329 @@
+/**
+********************************************************************************
+\file   timesynckcal-linuxdpshm.c
+
+\brief  CAL kernel timesync module using the openPOWERLINK Linux kernel driver
+
+This file contains an implementation for the kernel CAL timesync module which
+uses the openPOWERLINK Linux kernel driver interface. In addition SoC timestamp
+forwarding feature implementation is done by creating a shared memory for the
+user and kernel.
+
+The sync module is responsible to synchronize the user layer.
+
+\ingroup module_timesynckcal
+*******************************************************************************/
+
+/*------------------------------------------------------------------------------
+Copyright (c) 2017, Kalycito Infotech Private Limited
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holders nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+------------------------------------------------------------------------------*/
+
+//------------------------------------------------------------------------------
+// includes
+//------------------------------------------------------------------------------
+#include <common/oplkinc.h>
+#include <kernel/timesynckcal.h>
+
+#include <linux/slab.h>
+#include <linux/sched.h>
+#include <linux/wait.h>
+
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+#include <drvintf.h>
+#endif
+
+//============================================================================//
+//            G L O B A L   D E F I N I T I O N S                             //
+//============================================================================//
+
+//------------------------------------------------------------------------------
+// const defines
+//------------------------------------------------------------------------------
+
+//------------------------------------------------------------------------------
+// module global vars
+//------------------------------------------------------------------------------
+
+//------------------------------------------------------------------------------
+// global function prototypes
+//------------------------------------------------------------------------------
+
+//============================================================================//
+//            P R I V A T E   D E F I N I T I O N S                           //
+//============================================================================//
+
+//------------------------------------------------------------------------------
+// const defines
+//------------------------------------------------------------------------------
+
+//------------------------------------------------------------------------------
+// local types
+//------------------------------------------------------------------------------
+/**
+\brief Memory instance for user timesync module
+
+The structure contains all necessary information needed by the timesync CAL
+module for dual processor design.
+*/
+typedef struct
+{
+    wait_queue_head_t       syncWaitQueue;   ///< Wait queue for time sync event
+    BOOL                    fSync;           ///< Flag for wait sync event
+    BOOL                    fInitialized;    ///< Flag for timesynckcal module initialization
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+    tTimesyncSharedMemory*  pSharedMemory;   ///< Shared timesync structure
+#endif
+} tTimesynckCalInstance;
+
+//------------------------------------------------------------------------------
+// local vars
+//------------------------------------------------------------------------------
+static tTimesynckCalInstance instance_l; ///< Instance variable of kernel timesync module
+
+//------------------------------------------------------------------------------
+// local function prototypes
+//------------------------------------------------------------------------------
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+static tOplkError initTimeSyncShm(void);
+static void       exitTimeSyncShm(void);
+#endif
+
+//============================================================================//
+//            P U B L I C   F U N C T I O N S                                 //
+//============================================================================//
+
+//------------------------------------------------------------------------------
+/**
+\brief  Initialize kernel CAL timesync module
+
+The function initializes the kernel CAL timesync module.
+
+\return The function returns a tOplkError error code.
+\retval kErrorOk  Timesynckcal initialization successful
+\retval other     Timesynckcal initialization fails
+
+\ingroup module_timesynckcal
+*/
+//------------------------------------------------------------------------------
+tOplkError timesynckcal_init(void)
+{
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+    tOplkError ret;
+#endif
+
+    OPLK_MEMSET(&instance_l, 0, sizeof(tTimesynckCalInstance));
+
+    init_waitqueue_head(&instance_l.syncWaitQueue);
+    instance_l.fInitialized = TRUE;
+
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+    ret = initTimeSyncShm();
+    if (ret != kErrorOk)
+        return ret;
+#endif
+
+    return kErrorOk;
+}
+
+//------------------------------------------------------------------------------
+/**
+\brief  Clean up CAL timesync module
+
+The function cleans up the CAL timesync module
+
+\ingroup module_timesynckcal
+*/
+//------------------------------------------------------------------------------
+void timesynckcal_exit(void)
+{
+    instance_l.fInitialized = FALSE;
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+    exitTimeSyncShm();
+#endif
+}
+
+//------------------------------------------------------------------------------
+/**
+\brief  Send a sync event
+
+The function sends a sync event.
+
+\return The function returns a tOplkError error code.
+\retval kErrorOk  Send sync event successful
+
+\ingroup module_timesynckcal
+*/
+//------------------------------------------------------------------------------
+tOplkError timesynckcal_sendSyncEvent(void)
+{
+    if (instance_l.fInitialized)
+    {
+        instance_l.fSync = TRUE;
+        wake_up_interruptible(&instance_l.syncWaitQueue);
+    }
+
+    return kErrorOk;
+}
+
+//------------------------------------------------------------------------------
+/**
+\brief  Wait for a sync event
+
+The function waits for a sync event
+
+\return The function returns a tOplkError error code.
+\retval kErrorOk          Wait sync event successful
+\retval kErrorRetry       wait_event_interruptible_timeout returns NULL
+\retval kErrorNoResource  Flag for timesynckcal module initialization is not set
+
+\ingroup module_timesynckcal
+*/
+//------------------------------------------------------------------------------
+tOplkError timesynckcal_waitSyncEvent(void)
+{
+    int ret;
+    int timeout = 1000 * HZ / 1000;
+
+    if (!instance_l.fInitialized)
+        return kErrorNoResource;
+
+    ret = wait_event_interruptible_timeout(instance_l.syncWaitQueue,
+                                           instance_l.fSync,
+                                           timeout);
+    if (ret == 0)
+        return kErrorRetry;
+
+    instance_l.fSync = FALSE;
+
+    return kErrorOk;
+}
+
+//------------------------------------------------------------------------------
+/**
+\brief  Enable sync events
+
+The function enables sync events.
+
+\param[in]      fEnable_p           Enable/disable sync event
+
+\return The function returns a tOplkError error code.
+\retval kErrorOk Successfully enables sync events
+
+\ingroup module_timesynckcal
+*/
+//------------------------------------------------------------------------------
+tOplkError timesynckcal_controlSync(BOOL fEnable_p)
+{
+    UNUSED_PARAMETER(fEnable_p);
+
+    return kErrorOk;
+}
+
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+//------------------------------------------------------------------------------
+/**
+\brief  Get timesync shared memory
+
+The function returns the reference to the timesync shared memory.
+
+\return The function returns a pointer to the timesync shared memory.
+\retval Returns a timesync shared memory pointer
+
+\ingroup module_timesynckcal
+*/
+//------------------------------------------------------------------------------
+tTimesyncSharedMemory* timesynckcal_getSharedMemory(void)
+{
+    return instance_l.pSharedMemory;
+}
+
+//============================================================================//
+//            P R I V A T E   F U N C T I O N S                               //
+//============================================================================//
+/// \name Private Functions
+/// \{
+//------------------------------------------------------------------------------
+/**
+\brief  Initialize timesync shared memory
+
+This function initializes the shared memory buffer for timesync module.
+
+\return The function returns a tOplkError error code.
+\retval kErrorOk          Timesync shared memory initialization successful
+\retval kErrorNoResource  Received timesync shared memory is NULL
+\retval other             Timesync initialization fails
+*/
+//------------------------------------------------------------------------------
+static tOplkError initTimeSyncShm(void)
+{
+    tOplkError ret;
+
+    // Initiates the shared memory for the timesync module
+    ret = drvintf_initTimesyncShm();
+    if (ret != kErrorOk)
+    {
+        DEBUG_LVL_ERROR_TRACE("%s(): Timesync initialization failed (0x%X)\n",
+                              ret);
+        return ret;
+    }
+
+    // Receives the address of timesync shared memory to be passed to user layer
+    instance_l.pSharedMemory = drvintf_getTimesyncShm();
+
+    if (instance_l.pSharedMemory == NULL)
+    {
+        DEBUG_LVL_ERROR_TRACE("%s(): Timesync shared memory is NULL\n",
+                              __func__);
+        return kErrorNoResource;
+    }
+
+    return kErrorOk;
+}
+
+//------------------------------------------------------------------------------
+/**
+\brief  Exit timesync shared memory
+
+This function unmaps the SoC timesync shared memory.
+
+\return The function returns a tOplkError error code.
+*/
+//------------------------------------------------------------------------------
+static void exitTimeSyncShm(void)
+{
+    if (instance_l.pSharedMemory != NULL)
+    {
+        // Frees the timesync shared memory
+        if (drvintf_exitTimesyncShm() != kErrorOk)
+            DEBUG_LVL_ERROR_TRACE("%s(): Timesync shared memory exit failed",
+                                  __func__);
+
+        instance_l.pSharedMemory = NULL;
+    }
+}
+#endif
+
+/// \}

--- a/stack/src/user/timesync/timesyncucal-linuxdpshm.c
+++ b/stack/src/user/timesync/timesyncucal-linuxdpshm.c
@@ -1,0 +1,280 @@
+/**
+********************************************************************************
+\file   timesyncucal-linuxdpshm.c
+
+\brief  Sync implementation for the user CAL timesync module using Linux ioctl
+
+This file contains a sync implementation for the user CAL timesync module. It
+uses a Linux ioctl call for synchronisation. In addition SoC timestamp
+forwarding feature implementation is done by creating a shared memory for the
+user and kernel.
+
+\ingroup module_timesyncucal
+*******************************************************************************/
+
+/*------------------------------------------------------------------------------
+Copyright (c) 2017, Kalycito Infotech Private Limited
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holders nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+------------------------------------------------------------------------------*/
+
+//------------------------------------------------------------------------------
+// includes
+//------------------------------------------------------------------------------
+#include <common/oplkinc.h>
+#include <user/timesyncucal.h>
+#include <user/ctrlucal.h>
+#include <common/driver.h>
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+#include <common/memmap.h>
+#endif
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <time.h>
+
+//============================================================================//
+//            G L O B A L   D E F I N I T I O N S                             //
+//============================================================================//
+
+//------------------------------------------------------------------------------
+// const defines
+//------------------------------------------------------------------------------
+
+//------------------------------------------------------------------------------
+// module global vars
+//------------------------------------------------------------------------------
+
+//------------------------------------------------------------------------------
+// global function prototypes
+//------------------------------------------------------------------------------
+
+//============================================================================//
+//            P R I V A T E   D E F I N I T I O N S                           //
+//============================================================================//
+
+//------------------------------------------------------------------------------
+// const defines
+//------------------------------------------------------------------------------
+
+//------------------------------------------------------------------------------
+// local types
+//------------------------------------------------------------------------------
+/**
+\brief Memory instance for user timesync module
+
+The structure contains all necessary information needed by the timesync CAL
+module for dual processor design.
+*/
+typedef struct
+{
+    OPLK_FILE_HANDLE        fd;             ///< File descriptor for POWERLINK device
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+    tTimesyncSharedMemory*  pSharedMemory;  ///< Pointer to shared memory
+#endif
+}tTimesyncucalInstance;
+
+//------------------------------------------------------------------------------
+// local vars
+//------------------------------------------------------------------------------
+static tTimesyncucalInstance instance_l;
+
+//------------------------------------------------------------------------------
+// local function prototypes
+//------------------------------------------------------------------------------
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+static tOplkError getTimeSyncShm(void);
+static void       releaseTimeSyncShm(void);
+#endif
+
+//============================================================================//
+//            P U B L I C   F U N C T I O N S                                 //
+//============================================================================//
+
+//------------------------------------------------------------------------------
+/**
+\brief  Initialize user CAL timesync module
+
+The function initializes the user CAL timesync module
+
+\param[in]      pfnSyncCb_p         Function that is called in case of sync event
+
+\return The function returns a tOplkError error code.
+\retval kErrorOk  Timesyncucal initialization successful
+\retval other     Timesyncucal initialization fails
+
+\ingroup module_timesyncucal
+*/
+//------------------------------------------------------------------------------
+tOplkError timesyncucal_init(tSyncCb pfnSyncCb_p)
+{
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+    tOplkError ret;
+#endif
+
+    UNUSED_PARAMETER(pfnSyncCb_p);
+
+    OPLK_MEMSET(&instance_l, 0, sizeof(tTimesyncucalInstance));
+    instance_l.fd = ctrlucal_getFd();
+
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+    ret = getTimeSyncShm();
+    if (ret != kErrorOk)
+        return ret;
+#endif
+
+    return kErrorOk;
+}
+
+//------------------------------------------------------------------------------
+/**
+\brief  Clean up user CAL timesync module
+
+The function cleans up the user CAL timesync module
+
+\ingroup module_timesyncucal
+*/
+//------------------------------------------------------------------------------
+void timesyncucal_exit(void)
+{
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+    releaseTimeSyncShm();
+#endif
+}
+
+//------------------------------------------------------------------------------
+/**
+\brief  Wait for a sync event
+
+The function waits for a sync event.
+
+\param[in]      timeout_p           Specifies a timeout in microseconds. If 0 it waits
+                                    forever.
+
+\return The function returns a tOplkError error code.
+\retval kErrorOk                    Successfully received sync event
+\retval kErrorGeneralError          Error while waiting on sync event
+
+\ingroup module_timesyncucal
+*/
+//------------------------------------------------------------------------------
+tOplkError timesyncucal_waitSyncEvent(ULONG timeout_p)
+{
+    int ret;
+
+    ret = ioctl(instance_l.fd, PLK_CMD_TIMESYNC_SYNC, timeout_p);
+    if (ret != 0)
+        return kErrorGeneralError;
+
+    return kErrorOk;
+}
+
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+//------------------------------------------------------------------------------
+/**
+\brief  Get timesync shared memory
+
+The function returns the reference to the timesync shared memory.
+
+\return The function returns a pointer to the timesync shared memory.
+
+\ingroup module_timesyncucal
+*/
+//------------------------------------------------------------------------------
+tTimesyncSharedMemory* timesyncucal_getSharedMemory(void)
+{
+    return instance_l.pSharedMemory;
+}
+
+//============================================================================//
+//            P R I V A T E   F U N C T I O N S                               //
+//============================================================================//
+/// \name Private Functions
+/// \{
+//------------------------------------------------------------------------------
+/**
+\brief  Get timesync shared memory
+
+This function gets the available SoC timesync shared memory using ioctl and
+maps the shared memory using memmap.
+
+\return The function returns a tOplkError error code.
+\retval kErrorOk          Get timesync shared memory is successful
+\retval kErrorNoResource  Kernel or User timesync shared memory is null
+*/
+//------------------------------------------------------------------------------
+static tOplkError getTimeSyncShm(void)
+{
+    ULONG* pSocTimesyncMem = NULL;
+    int    ret;
+
+    // Gets the timesync shared memory kernel address
+    ret = ioctl(instance_l.fd, PLK_CMD_TIMESYNC_MAP_OFFSET, &pSocTimesyncMem);
+
+    if (ret < 0)
+    {
+       DEBUG_LVL_ERROR_TRACE("%s(): IOCTL failed! Couldn't get timesync shared memory\n",
+                             __func__);
+       return kErrorGeneralError;
+    }
+
+    if (pSocTimesyncMem == NULL)
+    {
+        DEBUG_LVL_ERROR_TRACE("%s(): Timesync shared memory is NULL\n", __func__);
+        return kErrorNoResource;
+    }
+
+    // Maps the kernel layer buffer address into user application virtual address space
+    instance_l.pSharedMemory = memmap_mapKernelBuffer(pSocTimesyncMem,
+                                                      sizeof(tTimesyncSharedMemory));
+
+    if (instance_l.pSharedMemory == NULL)
+    {
+        DEBUG_LVL_ERROR_TRACE("%s(): Couldn't map timesync shared memory\n",
+                              __func__);
+        return kErrorNoResource;
+    }
+
+    return kErrorOk;
+}
+//------------------------------------------------------------------------------
+/**
+\brief  Release timesync shared memory
+
+This function releases the unmapped timesync shared memory.
+
+*/
+//------------------------------------------------------------------------------
+static void releaseTimeSyncShm(void)
+{
+    if (instance_l.pSharedMemory != NULL)
+    {
+        // Unmaps timesync shared memory
+        memmap_unmapKernelBuffer(instance_l.pSharedMemory);
+        instance_l.pSharedMemory = NULL;
+    }
+}
+#endif
+/// \}


### PR DESCRIPTION
 - This commit introduces the SoC time forwarding capability to the
   Zynq hybrid design using a shared memory.
 - Create a shared memory between kernel and user to hold SoC time
   stamps.
 - Free the shared memory during exit.

Change-Id: I89775ff97b6af776e9358105c2859ec86971606a

This pull request incorporates the comments for the previous pull request #235 