### PR TITLE
[TASK] Increase tightly coupled memory size in Terasic DE2i-150

### DIFF
--- a/hardware/boards/terasic-de2i-150/mn-single-pcie-drv/quartus/mnSinglePcieDrv.qsys
+++ b/hardware/boards/terasic-de2i-150/mn-single-pcie-drv/quartus/mnSinglePcieDrv.qsys
@@ -406,7 +406,7 @@
   <parameter name="AUTO_CLK100_CLOCK_DOMAIN" value="1" />
   <parameter name="AUTO_CLK100_RESET_DOMAIN" value="1" />
   <parameter name="cpu0_resetCpuBridge" value="flash_bridge" />
-  <parameter name="tcmemSize" value="20480" />
+  <parameter name="tcmemSize" value="21504" />
  </module>
  <module
    kind="altera_generic_tristate_controller"


### PR DESCRIPTION
 - MN net time distribution feature implementation causes code
   segment overflow in tightly coupled memory due to the code
   changes in dllkevent.c.
 - To overcome this issue, 'tcmemsize' is increased from 20 kB to
   21 kB.

Change-Id: I810e71a051dde34107a3d10a8b9926045b0356e6