### PR TITLE
[FEATURE] Add SoC time stamp forwarding feature in Linux PCIe design

### DIFF
--- a/drivers/linux/drv_kernelmod_pcie/CMakeLists.txt
+++ b/drivers/linux/drv_kernelmod_pcie/CMakeLists.txt
@@ -147,7 +147,7 @@ SET(MODULE_SOURCE_FILES
     ${COMMON_SOURCE_DIR}/debugstr.c
     ${CONTRIB_SOURCE_DIR}/trace/trace-printk.c
     ${KERNEL_SOURCE_DIR}/timesync/timesynck.c
-    ${KERNEL_SOURCE_DIR}/timesync/timesynckcal-linuxkernel.c
+    ${KERNEL_SOURCE_DIR}/timesync/timesynckcal-linuxdpshm.c
     ${KERNEL_SOURCE_DIR}/veth/veth-linuxdpshm.c
     ${ARCH_SOURCE_DIR}/target-linuxkernel.c
     )

--- a/drivers/linux/drv_kernelmod_pcie/drvintf-dualprocshm.c
+++ b/drivers/linux/drv_kernelmod_pcie/drvintf-dualprocshm.c
@@ -16,7 +16,7 @@ provide direct access to user application for specific shared memory regions.
 *******************************************************************************/
 
 /*------------------------------------------------------------------------------
-Copyright (c) 2015, Kalycito Infotech Private Limited
+Copyright (c) 2017, Kalycito Infotech Private Limited
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
 All rights reserved.
 
@@ -79,6 +79,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define DUALPROCSHM_BUFF_ID_ERRHDLR     12
 #define DUALPROCSHM_BUFF_ID_PDO         13
 #define BENCHMARK_OFFSET                0x00001000
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+#define DUALPROCSHM_BUFF_ID_TIMESYNC    14
+#endif
 
 //------------------------------------------------------------------------------
 // global function prototypes
@@ -114,6 +117,9 @@ typedef struct
     tCircBufInstance*       apDllQueueInst[DRV_DLLCALTXQUEUE_INSTCNT]; ///< DLL queue instances.
     tErrHndObjects*         pErrorObjects;                      ///< Pointer to error objects.
     BOOL                    fDriverActive;                      ///< Flag to identify status of driver interface.
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+    tTimesyncSharedMemory*  pTimesyncShm;                       ///< Pointer to timesync shared memory
+#endif
 #if defined(CONFIG_INCLUDE_VETH)
     BOOL                    fVEthActive;                        ///< Flag to indicate whether the VEth interface is intialized.
     tDrvIntfCbVeth          pfnCbVeth;                          ///< Callback function to the VEth interface.
@@ -914,6 +920,11 @@ Maps the kernel layer memory specified by the caller into user layer.
 \param[in]      size_p              Size of the memory to be mapped.
 
 \return Returns tOplkError error code.
+\retval kErrorOk                   Kernel layer memory to user layer memory
+                                   mapping is successful.
+\retval kErrorNoResource           Kernel to User memory mapping is not successful.
+\retval kErrorInvalidInstanceParam PCP buffer pointer lies outside the shared
+                                   memory region.
 
 \ingroup module_driver_linux_kernel_pcie
 */
@@ -970,12 +981,8 @@ tOplkError drvintf_mapKernelMem(const void* pKernelMem_p,
         drvIntfInstance_l.shmSize = remoteProcSharedMemInst.span;
     }
 
-    if ((ULONG)pKernelMem_p <= drvIntfInstance_l.shmMemRemote)
-    {
-        DEBUG_LVL_ERROR_TRACE("%s() Error: PCP buffer pointer lies outside the shared memory region\n");
-        return kErrorInvalidInstanceParam;
-    }
-    else
+    if (((ULONG)pKernelMem_p <= (drvIntfInstance_l.shmMemRemote + drvIntfInstance_l.shmSize)) &&
+        (ULONG)pKernelMem_p >= drvIntfInstance_l.shmMemRemote)
     {
         *ppUserMem_p = (void*)((ULONG)pKernelMem_p -
                                (ULONG)drvIntfInstance_l.shmMemRemote +
@@ -985,6 +992,26 @@ tOplkError drvintf_mapKernelMem(const void* pKernelMem_p,
                                 drvIntfInstance_l.shmMemRemote,
                                 (ULONG)pKernelMem_p,
                                 (ULONG)(*ppUserMem_p));
+    }
+    else
+    {
+        // Checks whether the passed memory is a local memory
+        if (((ULONG)pKernelMem_p <= (drvIntfInstance_l.shmMemLocal + drvIntfInstance_l.shmSize)) &&
+            (ULONG)pKernelMem_p >= drvIntfInstance_l.shmMemLocal)
+        {
+            *ppUserMem_p = (void*)((ULONG)pKernelMem_p);
+             DEBUG_LVL_DRVINTF_TRACE("LA: 0x%lX, RA: 0x%lX, KA: 0x%lX, UA: 0x%lX\n",
+                                     drvIntfInstance_l.shmMemLocal,
+                                     drvIntfInstance_l.shmMemRemote,
+                                     (ULONG)pKernelMem_p,
+                                     (ULONG)(*ppUserMem_p));
+        }
+        else
+        {
+            DEBUG_LVL_ERROR_TRACE("%s() Error: PCP buffer pointer lies outside the shared memory region\n",
+                                  __func__);
+            return kErrorInvalidInstanceParam;
+        }
     }
 
     return kErrorOk;
@@ -1079,6 +1106,120 @@ ULONG drvintf_getFileBufferSize(void)
 {
     return CONFIG_CTRL_FILE_CHUNK_SIZE;
 }
+
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+//------------------------------------------------------------------------------
+/**
+\brief  Initialize timesync shared memory
+
+This function retrieves the shared memory for the timesync module. This memory
+is accessible to user space through ioctl calls.
+
+\return The function returns a tOplkError error code.
+\retval kErrorOk               Successful timesync shared memory initialization.
+\retval kErrorInvalidOperation Initialization not possible because driver is not
+                               active.
+\retval kErrorNoResource       Failed to get shared memory from dualprocshm.
+
+\ingroup module_driver_linux_kernel_zynq
+*/
+//------------------------------------------------------------------------------
+tOplkError drvintf_initTimesyncShm(void)
+{
+    tDualprocReturn dualRet;
+    void*           pBase;
+    size_t          span;
+
+    if (!drvIntfInstance_l.fDriverActive || (drvIntfInstance_l.pTimesyncShm != NULL))
+    {
+        DEBUG_LVL_ERROR_TRACE("%s(): Driver is not active or timesync shared memory buffer is not empty\n",
+                              __func__);
+        return kErrorInvalidOperation;
+    }
+
+    dualRet = dualprocshm_getMemory(drvIntfInstance_l.dualProcDrvInst, // Driver instance
+                                    DUALPROCSHM_BUFF_ID_TIMESYNC,      // ID of timesync memory buffer
+                                    &pBase,                            // Base address of the requested memory
+                                    &span,                             // Size of the memory to be allocated
+                                    FALSE);                            // Retrieves address from address mapping table
+    if (dualRet != kDualprocSuccessful)
+    {
+        DEBUG_LVL_ERROR_TRACE("%s(): Couldn't get timesync shared memory buffer (0x%X)\n",
+                              __func__,
+                              dualRet);
+        return kErrorNoResource;
+    }
+
+    if (span < sizeof(tTimesyncSharedMemory))
+    {
+        DEBUG_LVL_ERROR_TRACE("%s(): Timesync shared memory buffer too small\n",
+                              __func__);
+        return kErrorNoResource;
+    }
+
+    drvIntfInstance_l.pTimesyncShm = (tTimesyncSharedMemory*)pBase;
+
+    return kErrorOk;
+}
+
+//------------------------------------------------------------------------------
+/**
+\brief  Free timesync shared memory
+
+Frees the timesync shared memory.
+
+\return The function returns a tOplkError error code.
+\retval kErrorOk    Exit drvintf timesync shared memory successful.
+
+\ingroup module_driver_linux_kernel_zynq
+*/
+//------------------------------------------------------------------------------
+tOplkError drvintf_exitTimesyncShm(void)
+{
+    tOplkError ret;
+
+    if (drvIntfInstance_l.pTimesyncShm != NULL)
+    {
+        ret = dualprocshm_freeMemory(drvIntfInstance_l.dualProcDrvInst, // Driver instance
+                                     DUALPROCSHM_BUFF_ID_TIMESYNC,      // ID of timesync memory buffer
+                                     FALSE);                            // Clear address from address mapping table
+        if (ret != kDualprocSuccessful)
+        {
+            DEBUG_LVL_ERROR_TRACE("%s(): The dynamic memory buffer is not freed successfully\n",
+                                  __func__);
+        }
+
+        drvIntfInstance_l.pTimesyncShm = NULL;
+    }
+
+    return kErrorOk;
+}
+
+//------------------------------------------------------------------------------
+/**
+\brief  Get timesync shared memory
+
+This routine fetches the address of timesync shared memory to be passed to user
+layer.
+
+\return The function returns a pointer to the timesync shared memory.
+\retval Timesync shared memory pointer.
+
+\ingroup module_driver_linux_kernel_zynq
+*/
+//------------------------------------------------------------------------------
+tTimesyncSharedMemory* drvintf_getTimesyncShm(void)
+{
+    if (!drvIntfInstance_l.fDriverActive)
+    {
+        DEBUG_LVL_ERROR_TRACE("%s(): Driver is not active and timesync shared memory is not available\n",
+                              __func__);
+        return NULL;
+    }
+
+    return drvIntfInstance_l.pTimesyncShm;
+}
+#endif
 
 //============================================================================//
 //            P R I V A T E   F U N C T I O N S                               //

--- a/drivers/linux/drv_kernelmod_pcie/drvintf.h
+++ b/drivers/linux/drv_kernelmod_pcie/drvintf.h
@@ -9,7 +9,7 @@ openPOWERLINK PCIe driver interface to PCP - Header file
 *******************************************************************************/
 
 /*------------------------------------------------------------------------------
-Copyright (c) 2015, Kalycito Infotech Private Limited
+Copyright (c) 2017, Kalycito Infotech Private Limited
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
 All rights reserved.
 
@@ -46,6 +46,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <common/ctrlcal-mem.h>
 #include <common/dllcal.h>
 
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+#include <common/timesync.h>
+#endif
+
 //------------------------------------------------------------------------------
 // const defines
 //------------------------------------------------------------------------------
@@ -74,41 +78,46 @@ typedef tOplkError (*tDrvIntfCbVeth)(const tFrameInfo* pFrameInfo_p);
 extern "C"
 {
 #endif
-tOplkError drvintf_init(void);
-void       drvintf_exit(void);
-tOplkError drvintf_executeCmd(tCtrlCmd* ctrlCmd_p);
-tOplkError drvintf_waitSyncEvent(void);
-tOplkError drvintf_readInitParam(tCtrlInitParam* pInitParam_p);
-tOplkError drvintf_storeInitParam(const tCtrlInitParam* pInitParam_p);
-tOplkError drvintf_getStatus(UINT16* pStatus_p);
-tOplkError drvintf_getHeartbeat(UINT16* pHeartbeat_p);
+tOplkError             drvintf_init(void);
+void                   drvintf_exit(void);
+tOplkError             drvintf_executeCmd(tCtrlCmd* ctrlCmd_p);
+tOplkError             drvintf_waitSyncEvent(void);
+tOplkError             drvintf_readInitParam(tCtrlInitParam* pInitParam_p);
+tOplkError             drvintf_storeInitParam(const tCtrlInitParam* pInitParam_p);
+tOplkError             drvintf_getStatus(UINT16* pStatus_p);
+tOplkError             drvintf_getHeartbeat(UINT16* pHeartbeat_p);
 #if defined(CONFIG_INCLUDE_VETH)
-tOplkError drvintf_regVethHandler(tDrvIntfCbVeth pfnDrvIntfCbVeth_p);
-tOplkError drvintf_sendVethFrame(const tFrameInfo* pFrameInfo_p);
+tOplkError             drvintf_regVethHandler(tDrvIntfCbVeth pfnDrvIntfCbVeth_p);
+tOplkError             drvintf_sendVethFrame(const tFrameInfo* pFrameInfo_p);
 #endif
-tOplkError drvintf_sendAsyncFrame(tDllCalQueue queue_p,
-                                  size_t size_p,
-                                  const void* pData_p);
-tOplkError drvintf_writeErrorObject(UINT32 offset_p,
-                                    UINT32 errVal_p);
-tOplkError drvintf_readErrorObject(UINT32 offset_p,
-                                   UINT32* pErrVal_p);
-tOplkError drvintf_postEvent(const tEvent* pEvent_p);
-tOplkError drvintf_getEvent(tEvent* pK2UEvent_p,
-                            size_t* pSize_p);
-tOplkError drvintf_getPdoMem(void** ppPdoMem_p,
-                             size_t* pMemSize_p);
-tOplkError drvintf_freePdoMem(void** ppPdoMem_p,
-                              size_t memSize_p);
-tOplkError drvintf_getBenchmarkMem(void** ppBenchmarkMem_p);
-tOplkError drvintf_freeBenchmarkMem(void** ppBenchmarkMem_p);
-tOplkError drvintf_mapKernelMem(const void* pKernelMem_p,
-                                void** ppUserMem_p,
-                                size_t size_p);
-void       drvintf_unmapKernelMem(void** ppUserMem_p);
-tOplkError drvintf_writeFileBuffer(const tOplkApiFileChunkDesc* pDesc_p,
-                                   const void* pBuf_p);
-ULONG      drvintf_getFileBufferSize(void);
+tOplkError             drvintf_sendAsyncFrame(tDllCalQueue queue_p,
+                                              size_t size_p,
+                                              const void* pData_p);
+tOplkError             drvintf_writeErrorObject(UINT32 offset_p,
+                                                UINT32 errVal_p);
+tOplkError             drvintf_readErrorObject(UINT32 offset_p,
+                                               UINT32* pErrVal_p);
+tOplkError             drvintf_postEvent(const tEvent* pEvent_p);
+tOplkError             drvintf_getEvent(tEvent* pK2UEvent_p,
+                                        size_t* pSize_p);
+tOplkError             drvintf_getPdoMem(void** ppPdoMem_p,
+                                         size_t* pMemSize_p);
+tOplkError             drvintf_freePdoMem(void** ppPdoMem_p,
+                                          size_t memSize_p);
+tOplkError             drvintf_getBenchmarkMem(void** ppBenchmarkMem_p);
+tOplkError             drvintf_freeBenchmarkMem(void** ppBenchmarkMem_p);
+tOplkError             drvintf_mapKernelMem(const void* pKernelMem_p,
+                                            void** ppUserMem_p,
+                                            size_t size_p);
+void                   drvintf_unmapKernelMem(void** ppUserMem_p);
+tOplkError             drvintf_writeFileBuffer(const tOplkApiFileChunkDesc* pDesc_p,
+                                               const void* pBuf_p);
+ULONG                  drvintf_getFileBufferSize(void);
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+tOplkError             drvintf_initTimesyncShm(void);
+tOplkError             drvintf_exitTimesyncShm(void);
+tTimesyncSharedMemory* drvintf_getTimesyncShm(void);
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
 - This commit introduces the SoC time forwarding capability to the
   Linux PCIe design using a shared memory.
 - Create a shared memory between kernel and user to hold SoC time
   stamps.
 - Free the shared memory during exit.

Change-Id: I0d8273ecf54a29a7c9f582ce37d202b7e1d836f7

This supersedes the previous pull request #255