### PR TITLE
[TASK] Add API implementation of net time in windows target

### DIFF
--- a/stack/src/arch/windows/target-windows.c
+++ b/stack/src/arch/windows/target-windows.c
@@ -10,7 +10,7 @@ The file implements target specific functions used in the openPOWERLINK stack.
 *******************************************************************************/
 
 /*------------------------------------------------------------------------------
-Copyright (c) 2015, Kalycito Infotech Private Limited
+Copyright (c) 2017, Kalycito Infotech Private Limited
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
 All rights reserved.
 
@@ -42,6 +42,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //------------------------------------------------------------------------------
 #include <common/oplkinc.h>
 #include <common/target.h>
+
+#if (defined(CONFIG_INCLUDE_SOC_TIME_FORWARD) && defined(CONFIG_INCLUDE_NMT_MN))
+#include "time.h"
+#endif
 
 //============================================================================//
 //            G L O B A L   D E F I N I T I O N S                             //
@@ -290,6 +294,57 @@ tOplkError target_setDefaultGateway(UINT32 defaultGateway_p)
 
     return kErrorOk;
 }
+
+#if (defined(CONFIG_INCLUDE_SOC_TIME_FORWARD) && defined(CONFIG_INCLUDE_NMT_MN))
+//------------------------------------------------------------------------------
+/**
+\brief  Get system time
+
+The function returns the current system time.
+
+\param[out]      pNsec_p    Pointer to nanoseconds component of current timestamp.
+\param[out]      pSec_p     Pointer to seconds component of current timestamp.
+
+\return The function returns a tOplkError code
+
+\ingroup module_target
+*/
+//------------------------------------------------------------------------------
+tOplkError target_getSystemTime(tNetTime* pNetTime_p, BOOL* pValidSystemTime_p)
+{
+    time_t        currentTime;
+    LARGE_INTEGER tickPerSecond;
+    LARGE_INTEGER tick;
+
+    // Get the high resolution counter's accuracy and the current time in ticks
+    if ((QueryPerformanceFrequency(&tickPerSecond) != 1) ||
+        (QueryPerformanceCounter(&tick) != 1))
+    {
+        *pValidSystemTime_p = FALSE;
+        return kErrorGeneralError;
+    }
+
+    // Get seconds component of current timestamp
+    time(&currentTime);
+
+    if (currentTime == -1)
+    {
+        *pValidSystemTime_p = FALSE;
+        return kErrorGeneralError;
+    }
+
+    // Set seconds component of current timestamp
+    pNetTime_p->sec = (UINT32)currentTime;
+
+    // Windows supports microsecond level accuracy timestamps. So convert microseconds to nanoseconds
+    // Set the nanoseconds component of current timestamp
+    pNetTime_p->nsec = (UINT32)((tick.QuadPart % tickPerSecond.QuadPart) * 1000);
+
+    *pValidSystemTime_p = TRUE;
+
+    return kErrorOk;
+}
+#endif
 
 //============================================================================//
 //            P R I V A T E   F U N C T I O N S                               //


### PR DESCRIPTION
 - Get the current system time using the time() function and
   QueryPerformanceCounter() for microsecond level accuracy of
   timestamps.
 - Set the valid system time flag.

Change-Id: I87210d5e7778ed6a6e94276c62dc9d11f8d9fcd6