### PR TITLE
Fix stack sometimes not starting on 64-bit system

### DIFF
--- a/drivers/windows/drv_ndis_intermediate/drvintf.c
+++ b/drivers/windows/drv_ndis_intermediate/drvintf.c
@@ -364,7 +364,7 @@ stack. This allows user stack to access the PDO memory directly.
 */
 //------------------------------------------------------------------------------
 tOplkError drv_mapPdoMem(UINT8** ppKernelMem_p, UINT8** ppUserMem_p,
-                         size_t* pMemSize_p)
+                         UINT32* pMemSize_p)
 {
     tOplkError      ret;
 

--- a/drivers/windows/drv_ndis_intermediate/drvintf.h
+++ b/drivers/windows/drv_ndis_intermediate/drvintf.h
@@ -87,7 +87,7 @@ tOplkError  drv_sendAsyncFrame(UINT8* pArg_p);
 tOplkError  drv_writeErrorObject(tErrHndIoctl* pWriteObject_p);
 tOplkError  drv_readErrorObject(tErrHndIoctl* pReadObject_p);
 tOplkError  drv_mapPdoMem(UINT8** ppKernelMem_p, UINT8** ppUserMem_p,
-                          size_t* pMemSize_p);
+                          UINT32* pMemSize_p);
 void        drv_unMapPdoMem(UINT8* pMem_p, size_t memSize_p);
 
 #ifdef __cplusplus

--- a/drivers/windows/drv_ndis_intermediate/main.c
+++ b/drivers/windows/drv_ndis_intermediate/main.c
@@ -548,7 +548,7 @@ NTSTATUS powerlinkIoctl(PDEVICE_OBJECT pDeviceObject_p, PIRP pIrp_p)
             tMemStruc*   pMemStruc = (tMemStruc*)pIrp_p->AssociatedIrp.SystemBuffer;
             oplkRet = drv_mapPdoMem((UINT8**)&pMemStruc->pKernelAddr,
                                     (UINT8**)&pMemStruc->pUserAddr,
-                                    (size_t*)&pMemStruc->size);
+                                    &pMemStruc->size);
 
             if (oplkRet != kErrorOk)
             {


### PR DESCRIPTION
Here was a pointer of **UIN32*** casted to **size_t*** , but size_t is 64-bit instead of 32-bit on 64-bit Windows.