### PR TITLE
[FEATURE] Add SoC time stamp forwarding feature in Linux PCIe design

### DIFF
--- a/drivers/linux/drv_kernelmod_pcie/CMakeLists.txt
+++ b/drivers/linux/drv_kernelmod_pcie/CMakeLists.txt
@@ -147,7 +147,7 @@ SET(MODULE_SOURCE_FILES
     ${COMMON_SOURCE_DIR}/debugstr.c
     ${CONTRIB_SOURCE_DIR}/trace/trace-printk.c
     ${KERNEL_SOURCE_DIR}/timesync/timesynck.c
-    ${KERNEL_SOURCE_DIR}/timesync/timesynckcal-linuxkernel.c
+    ${KERNEL_SOURCE_DIR}/timesync/timesynckcal-linuxdpshm.c
     ${KERNEL_SOURCE_DIR}/veth/veth-linuxdpshm.c
     ${ARCH_SOURCE_DIR}/target-linuxkernel.c
     )

--- a/drivers/linux/drv_kernelmod_pcie/drvintf.h
+++ b/drivers/linux/drv_kernelmod_pcie/drvintf.h
@@ -9,7 +9,7 @@ openPOWERLINK PCIe driver interface to PCP - Header file
 *******************************************************************************/
 
 /*------------------------------------------------------------------------------
-Copyright (c) 2015, Kalycito Infotech Private Limited
+Copyright (c) 2017, Kalycito Infotech Private Limited
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
 All rights reserved.
 
@@ -46,6 +46,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <common/ctrlcal-mem.h>
 #include <common/dllcal.h>
 
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+#include <common/timesync.h>
+#endif
+
 //------------------------------------------------------------------------------
 // const defines
 //------------------------------------------------------------------------------
@@ -74,41 +78,46 @@ typedef tOplkError (*tDrvIntfCbVeth)(const tFrameInfo* pFrameInfo_p);
 extern "C"
 {
 #endif
-tOplkError drvintf_init(void);
-void       drvintf_exit(void);
-tOplkError drvintf_executeCmd(tCtrlCmd* ctrlCmd_p);
-tOplkError drvintf_waitSyncEvent(void);
-tOplkError drvintf_readInitParam(tCtrlInitParam* pInitParam_p);
-tOplkError drvintf_storeInitParam(const tCtrlInitParam* pInitParam_p);
-tOplkError drvintf_getStatus(UINT16* pStatus_p);
-tOplkError drvintf_getHeartbeat(UINT16* pHeartbeat_p);
+tOplkError             drvintf_init(void);
+void                   drvintf_exit(void);
+tOplkError             drvintf_executeCmd(tCtrlCmd* ctrlCmd_p);
+tOplkError             drvintf_waitSyncEvent(void);
+tOplkError             drvintf_readInitParam(tCtrlInitParam* pInitParam_p);
+tOplkError             drvintf_storeInitParam(const tCtrlInitParam* pInitParam_p);
+tOplkError             drvintf_getStatus(UINT16* pStatus_p);
+tOplkError             drvintf_getHeartbeat(UINT16* pHeartbeat_p);
 #if defined(CONFIG_INCLUDE_VETH)
-tOplkError drvintf_regVethHandler(tDrvIntfCbVeth pfnDrvIntfCbVeth_p);
-tOplkError drvintf_sendVethFrame(const tFrameInfo* pFrameInfo_p);
+tOplkError             drvintf_regVethHandler(tDrvIntfCbVeth pfnDrvIntfCbVeth_p);
+tOplkError             drvintf_sendVethFrame(const tFrameInfo* pFrameInfo_p);
 #endif
-tOplkError drvintf_sendAsyncFrame(tDllCalQueue queue_p,
-                                  size_t size_p,
-                                  const void* pData_p);
-tOplkError drvintf_writeErrorObject(UINT32 offset_p,
-                                    UINT32 errVal_p);
-tOplkError drvintf_readErrorObject(UINT32 offset_p,
-                                   UINT32* pErrVal_p);
-tOplkError drvintf_postEvent(const tEvent* pEvent_p);
-tOplkError drvintf_getEvent(tEvent* pK2UEvent_p,
-                            size_t* pSize_p);
-tOplkError drvintf_getPdoMem(void** ppPdoMem_p,
-                             size_t* pMemSize_p);
-tOplkError drvintf_freePdoMem(void** ppPdoMem_p,
-                              size_t memSize_p);
-tOplkError drvintf_getBenchmarkMem(void** ppBenchmarkMem_p);
-tOplkError drvintf_freeBenchmarkMem(void** ppBenchmarkMem_p);
-tOplkError drvintf_mapKernelMem(const void* pKernelMem_p,
-                                void** ppUserMem_p,
-                                size_t size_p);
-void       drvintf_unmapKernelMem(void** ppUserMem_p);
-tOplkError drvintf_writeFileBuffer(const tOplkApiFileChunkDesc* pDesc_p,
-                                   const void* pBuf_p);
-ULONG      drvintf_getFileBufferSize(void);
+tOplkError             drvintf_sendAsyncFrame(tDllCalQueue queue_p,
+                                              size_t size_p,
+                                              const void* pData_p);
+tOplkError             drvintf_writeErrorObject(UINT32 offset_p,
+                                                UINT32 errVal_p);
+tOplkError             drvintf_readErrorObject(UINT32 offset_p,
+                                               UINT32* pErrVal_p);
+tOplkError             drvintf_postEvent(const tEvent* pEvent_p);
+tOplkError             drvintf_getEvent(tEvent* pK2UEvent_p,
+                                        size_t* pSize_p);
+tOplkError             drvintf_getPdoMem(void** ppPdoMem_p,
+                                         size_t* pMemSize_p);
+tOplkError             drvintf_freePdoMem(void** ppPdoMem_p,
+                                          size_t memSize_p);
+tOplkError             drvintf_getBenchmarkMem(void** ppBenchmarkMem_p);
+tOplkError             drvintf_freeBenchmarkMem(void** ppBenchmarkMem_p);
+tOplkError             drvintf_mapKernelMem(const void* pKernelMem_p,
+                                            void** ppUserMem_p,
+                                            size_t size_p);
+void                   drvintf_unmapKernelMem(void** ppUserMem_p);
+tOplkError             drvintf_writeFileBuffer(const tOplkApiFileChunkDesc* pDesc_p,
+                                               const void* pBuf_p);
+ULONG                  drvintf_getFileBufferSize(void);
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+tOplkError             drvintf_initTimesyncShm(void);
+tOplkError             drvintf_exitTimesyncShm(void);
+tTimesyncSharedMemory* drvintf_getTimesyncShm(void);
+#endif
 
 #ifdef __cplusplus
 }

--- a/drivers/linux/drv_kernelmod_pcie/main.c
+++ b/drivers/linux/drv_kernelmod_pcie/main.c
@@ -12,7 +12,7 @@ for the openPOWERLINK kernel stack.
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
-Copyright (c) 2015, Kalycito Private Limited
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -175,6 +175,9 @@ static int          getEventForUser(unsigned long arg_p);
 static int          postEventFromUser(unsigned long arg_p);
 static int          writeFileBuffer(unsigned long arg_p);
 static int          getFileBufferSize(unsigned long arg_p);
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+static int          getSocTimestampAddress(unsigned long arg_p);
+#endif
 
 //------------------------------------------------------------------------------
 //  Kernel module specific data structures
@@ -582,6 +585,12 @@ static int plkIntfIoctl(struct inode* pInode_p,
             ret = getFileBufferSize(arg_p);
             break;
 
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+        case PLK_CMD_TIMESYNC_MAP_OFFSET:
+            ret = getSocTimestampAddress(arg_p);
+            break;
+#endif
+
         default:
             DEBUG_LVL_ERROR_TRACE("PLK: - Invalid command (cmd=%d type=%d)\n",
                                   _IOC_NR(cmd_p),
@@ -615,6 +624,9 @@ static int plkIntfMmap(struct file* pFile_p,
     tOplkError  ret = kErrorOk;
     ULONG       pageAddr = 0;
     BOOL        fPdoMem = FALSE;
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+    BOOL        fSocMem = FALSE;
+#endif
 
     UNUSED_PARAMETER(pFile_p);
 
@@ -657,6 +669,11 @@ static int plkIntfMmap(struct file* pFile_p,
         if (ret != kErrorOk)
             return -ENOMEM;
 
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+        if (pPciMem == (void*)pageAddr)
+            fSocMem = TRUE;
+#endif
+
         // Get the bus address of the passed memory
         pageAddr = pciedrv_getBarPhyAddr(0) + ((ULONG)pageAddr - pciedrv_getBarAddr(0));
     }
@@ -675,7 +692,11 @@ static int plkIntfMmap(struct file* pFile_p,
         return -EAGAIN;
     }
 
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+    if ((fPdoMem == TRUE) || (fSocMem == TRUE))
+#else
     if (fPdoMem == TRUE)
+#endif
     {
         // Get the bus address of the atomic access memory
         pageAddr = pciedrv_getBarPhyAddr(0) + ((ULONG)pPciMem + ATOMIC_MEM_OFFSET - pciedrv_getBarAddr(0));
@@ -1194,5 +1215,36 @@ static int getFileBufferSize(unsigned long arg_p)
 
     return 0;
 }
+
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+//------------------------------------------------------------------------------
+/**
+\brief  Get timesync SoC timestamp kernel address
+
+The function implements the ioctl for getting the timesync shared memory pointer.
+
+\param[in]      arg_p               Pointer to the timesync shared memory argument
+                                    passed by the ioctl interface.
+
+\return The function returns Linux error code.
+*/
+//------------------------------------------------------------------------------
+static int getSocTimestampAddress(unsigned long arg_p)
+{
+    tTimesyncSharedMemory* pSharedMemory;
+
+    // Gets the kernel address of timesync shared memory from timesync kernel CAL
+    pSharedMemory = timesynckcal_getSharedMemory();
+
+    if (pSharedMemory == NULL)
+        return -ENXIO;
+
+    // Copy the received kernel address to timesync user CAL
+    if (copy_to_user((void __user*)arg_p, &pSharedMemory, sizeof(tTimesyncSharedMemory*)))
+        return -EFAULT;
+
+    return 0;
+}
+#endif
 
 /// \}


### PR DESCRIPTION
 - This commit introduces the SoC time forwarding capability to the
   Linux PCIe design using a shared memory.
 - Create a shared memory between kernel and user to hold SoC time
   stamps.
 - Free the shared memory during exit.

Change-Id: I0d8273ecf54a29a7c9f582ce37d202b7e1d836f7