### PR TITLE
[TASK] Enable SoC timestamp forward feature for supported platforms

### DIFF
--- a/drivers/linux/drv_kernelmod_edrv/proj/cn/oplkcfg.h
+++ b/drivers/linux/drv_kernelmod_edrv/proj/cn/oplkcfg.h
@@ -11,6 +11,7 @@ This file contains the configuration options for the openPOWERLINK kernel module
 /*------------------------------------------------------------------------------
 Copyright (c) 2012, SYSTEC electronik GmbH
 Copyright (c) 2014, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2017, Kalycito Infotech Private Limited.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -57,6 +58,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // These macros define all modules which are included
 #define CONFIG_INCLUDE_PDO
+#define CONFIG_INCLUDE_SOC_TIME_FORWARD
 
 #define CONFIG_DLLCAL_QUEUE                         CIRCBUF_QUEUE
 

--- a/drivers/linux/drv_kernelmod_edrv/proj/mn/oplkcfg.h
+++ b/drivers/linux/drv_kernelmod_edrv/proj/mn/oplkcfg.h
@@ -11,6 +11,7 @@ This file contains the configuration options for the openPOWERLINK kernel module
 /*------------------------------------------------------------------------------
 Copyright (c) 2012, SYSTEC electronik GmbH
 Copyright (c) 2014, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2017, Kalycito Infotech Private Limited.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -61,6 +62,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONFIG_INCLUDE_VETH
 #define CONFIG_INCLUDE_CFM
 #define CONFIG_INCLUDE_PRES_FORWARD
+#define CONFIG_INCLUDE_SOC_TIME_FORWARD
 
 #define CONFIG_DLLCAL_QUEUE                         CIRCBUF_QUEUE
 

--- a/drivers/linux/drv_kernelmod_pcie/proj/mn/oplkcfg.h
+++ b/drivers/linux/drv_kernelmod_pcie/proj/mn/oplkcfg.h
@@ -13,7 +13,7 @@ equivalent configurations in user and kernel layers of the stack.
 /*------------------------------------------------------------------------------
 Copyright (c) 2012, SYSTEC electronik GmbH
 Copyright (c) 2014, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
-Copyright (c) 2015, Kalycito Infotech Private Limited
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -63,6 +63,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONFIG_INCLUDE_PDO
 #define CONFIG_INCLUDE_CFM
 #define CONFIG_INCLUDE_VETH
+#define CONFIG_INCLUDE_SOC_TIME_FORWARD
 
 #define CONFIG_DLLCAL_QUEUE                         CIRCBUF_QUEUE
 

--- a/drivers/linux/drv_kernelmod_zynq/proj/mn/oplkcfg.h
+++ b/drivers/linux/drv_kernelmod_zynq/proj/mn/oplkcfg.h
@@ -13,7 +13,7 @@ as the equivalent configurations in user and kernel layers of the stack.
 /*------------------------------------------------------------------------------
 Copyright (c) 2012, SYSTEC electronik GmbH
 Copyright (c) 2014, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
-Copyright (c) 2016, Kalycito Infotech Private Limited
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -63,6 +63,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONFIG_INCLUDE_PDO
 #define CONFIG_INCLUDE_CFM
 #define CONFIG_INCLUDE_VETH
+#define CONFIG_INCLUDE_SOC_TIME_FORWARD
 
 #define CONFIG_DLLCAL_QUEUE                         CIRCBUF_QUEUE
 

--- a/stack/proj/generic/liboplkmnapp-dualprocshm/oplkcfg.h
+++ b/stack/proj/generic/liboplkmnapp-dualprocshm/oplkcfg.h
@@ -11,7 +11,7 @@ application library without an OS which is using the dualprocshm interface.
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2017, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
-Copyright (c) 2014, Kalycito Infotech Private Limited.
+Copyright (c) 2017, Kalycito Infotech Private Limited.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -64,9 +64,7 @@ The generic defines are valid for the whole openPOWERLINK stack.
 #define CONFIG_INCLUDE_CFM
 #define CONFIG_INCLUDE_VETH
 #define CONFIG_INCLUDE_IP
-
-// Enable feature manually if the platform is supporting it (only C5 SoC and Zynq).
-//#define CONFIG_INCLUDE_SOC_TIME_FORWARD
+#define CONFIG_INCLUDE_SOC_TIME_FORWARD
 
 #ifndef BENCHMARK_MODULES
 #define BENCHMARK_MODULES                   (0 | \

--- a/stack/proj/generic/liboplkmndrv-dualprocshm/oplkcfg.h
+++ b/stack/proj/generic/liboplkmndrv-dualprocshm/oplkcfg.h
@@ -9,7 +9,7 @@ library without an OS which is using the dualprocshm interface.
 *******************************************************************************/
 
 /*------------------------------------------------------------------------------
-Copyright (c) 2015, Kalycito Infotech Private Limited.
+Copyright (c) 2017, Kalycito Infotech Private Limited.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -64,9 +64,7 @@ The generic defines are valid for the whole openPOWERLINK stack.
 #define CONFIG_INCLUDE_LEDK
 #define CONFIG_INCLUDE_SDO_ASND
 #define CONFIG_INCLUDE_VETH
-
-// Enable feature manually if the platform is supporting it (only C5 SoC and Zynq).
-//#define CONFIG_INCLUDE_SOC_TIME_FORWARD
+#define CONFIG_INCLUDE_SOC_TIME_FORWARD
 
 #ifndef BENCHMARK_MODULES
 #define BENCHMARK_MODULES                   (0 |\

--- a/stack/proj/linux/liboplkcn/oplkcfg.h
+++ b/stack/proj/linux/liboplkcn/oplkcfg.h
@@ -12,6 +12,7 @@ on Linux.
 /*------------------------------------------------------------------------------
 Copyright (c) 2012, SYSTEC electronik GmbH
 Copyright (c) 2017, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2017, Kalycito Infotech Private Limited.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -68,6 +69,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONFIG_INCLUDE_SDO_ASND
 #define CONFIG_INCLUDE_SDO_RW_MULTIPLE
 #define CONFIG_INCLUDE_MASND
+#define CONFIG_INCLUDE_SOC_TIME_FORWARD
 
 #define CONFIG_DLLCAL_QUEUE                         CIRCBUF_QUEUE
 

--- a/stack/proj/linux/liboplkcnapp-kernelintf/oplkcfg.h
+++ b/stack/proj/linux/liboplkcnapp-kernelintf/oplkcfg.h
@@ -12,6 +12,7 @@ application libary on Linux which is using the kernelspace interface.
 /*------------------------------------------------------------------------------
 Copyright (c) 2012, SYSTEC electronik GmbH
 Copyright (c) 2017, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2017, Kalycito Infotech Private Limited.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -67,6 +68,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONFIG_INCLUDE_SDOC
 #define CONFIG_INCLUDE_SDO_ASND
 #define CONFIG_INCLUDE_SDO_RW_MULTIPLE
+#define CONFIG_INCLUDE_SOC_TIME_FORWARD
 
 #define CONFIG_DLLCAL_QUEUE                             IOCTL_QUEUE
 

--- a/stack/proj/linux/liboplkcnapp-userintf/oplkcfg.h
+++ b/stack/proj/linux/liboplkcnapp-userintf/oplkcfg.h
@@ -12,6 +12,7 @@ application libary on Linux which is using the userspace interface.
 /*------------------------------------------------------------------------------
 Copyright (c) 2012, SYSTEC electronik GmbH
 Copyright (c) 2017, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2017, Kalycito Infotech Private Limited.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -68,6 +69,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONFIG_INCLUDE_SDO_ASND
 #define CONFIG_INCLUDE_SDO_RW_MULTIPLE
 #define CONFIG_INCLUDE_VETH
+#define CONFIG_INCLUDE_SOC_TIME_FORWARD
 
 #define CONFIG_DLLCAL_QUEUE                             CIRCBUF_QUEUE
 

--- a/stack/proj/linux/liboplkcndrv-pcap/oplkcfg.h
+++ b/stack/proj/linux/liboplkcndrv-pcap/oplkcfg.h
@@ -12,6 +12,7 @@ libary on Linux.
 /*------------------------------------------------------------------------------
 Copyright (c) 2012, SYSTEC electronik GmbH
 Copyright (c) 2014, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2017, Kalycito Infotech Private Limited.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -66,6 +67,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONFIG_INCLUDE_VETH
 #define CONFIG_INCLUDE_CFM
 #define CONFIG_INCLUDE_MASND
+#define CONFIG_INCLUDE_SOC_TIME_FORWARD
 
 #define CONFIG_DLLCAL_QUEUE                         CIRCBUF_QUEUE
 

--- a/stack/proj/linux/liboplkmn/oplkcfg.h
+++ b/stack/proj/linux/liboplkmn/oplkcfg.h
@@ -12,6 +12,7 @@ on Linux.
 /*------------------------------------------------------------------------------
 Copyright (c) 2012, SYSTEC electronik GmbH
 Copyright (c) 2017, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2017, Kalycito Infotech Private Limited.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -73,6 +74,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONFIG_INCLUDE_IP
 #define CONFIG_INCLUDE_CFM
 #define CONFIG_INCLUDE_PRES_FORWARD
+#define CONFIG_INCLUDE_SOC_TIME_FORWARD
 
 #define CONFIG_DLLCAL_QUEUE                         CIRCBUF_QUEUE
 

--- a/stack/proj/linux/liboplkmnapp-kernelintf/oplkcfg.h
+++ b/stack/proj/linux/liboplkmnapp-kernelintf/oplkcfg.h
@@ -12,6 +12,7 @@ application libary on Linux which is using the kernelspace interface.
 /*------------------------------------------------------------------------------
 Copyright (c) 2012, SYSTEC electronik GmbH
 Copyright (c) 2017, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2017, Kalycito Infotech Private Limited.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -72,6 +73,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONFIG_INCLUDE_VETH
 #define CONFIG_INCLUDE_CFM
 #define CONFIG_INCLUDE_PRES_FORWARD
+#define CONFIG_INCLUDE_SOC_TIME_FORWARD
 
 #define CONFIG_DLLCAL_QUEUE                             IOCTL_QUEUE
 

--- a/stack/proj/linux/liboplkmnapp-kernelpcp/oplkcfg.h
+++ b/stack/proj/linux/liboplkmnapp-kernelpcp/oplkcfg.h
@@ -12,7 +12,7 @@ application libary on Linux which is using the kernelspace interface.
 /*------------------------------------------------------------------------------
 Copyright (c) 2012, SYSTEC electronik GmbH
 Copyright (c) 2017, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
-Copyright (c) 2016, Kalycito Infotech Private Limited
+Copyright (c) 2017, Kalycito Infotech Private Limited
 
 All rights reserved.
 
@@ -73,6 +73,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONFIG_INCLUDE_SDO_RW_MULTIPLE
 #define CONFIG_INCLUDE_CFM
 #define CONFIG_INCLUDE_VETH
+#define CONFIG_INCLUDE_SOC_TIME_FORWARD
 
 #define CONFIG_DLLCAL_QUEUE                             IOCTL_QUEUE
 

--- a/stack/proj/linux/liboplkmnapp-userintf/oplkcfg.h
+++ b/stack/proj/linux/liboplkmnapp-userintf/oplkcfg.h
@@ -12,6 +12,7 @@ application libary on Linux which is using the userspace interface.
 /*------------------------------------------------------------------------------
 Copyright (c) 2012, SYSTEC electronik GmbH
 Copyright (c) 2017, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2017, Kalycito Infotech Private Limited.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -73,6 +74,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONFIG_INCLUDE_IP
 #define CONFIG_INCLUDE_CFM
 #define CONFIG_INCLUDE_PRES_FORWARD
+#define CONFIG_INCLUDE_SOC_TIME_FORWARD
 
 #define CONFIG_DLLCAL_QUEUE                             CIRCBUF_QUEUE
 

--- a/stack/proj/linux/liboplkmndrv-pcap/oplkcfg.h
+++ b/stack/proj/linux/liboplkmndrv-pcap/oplkcfg.h
@@ -12,6 +12,7 @@ on Linux.
 /*------------------------------------------------------------------------------
 Copyright (c) 2012, SYSTEC electronik GmbH
 Copyright (c) 2014, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2017, Kalycito Infotech Private Limited.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -67,6 +68,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONFIG_INCLUDE_VETH
 #define CONFIG_INCLUDE_CFM
 #define CONFIG_INCLUDE_PRES_FORWARD
+#define CONFIG_INCLUDE_SOC_TIME_FORWARD
 
 #define CONFIG_DLLCAL_QUEUE                         CIRCBUF_QUEUE
 

--- a/stack/proj/windows/liboplkcn/oplkcfg.h
+++ b/stack/proj/windows/liboplkcn/oplkcfg.h
@@ -12,6 +12,7 @@ on Linux.
 /*------------------------------------------------------------------------------
 Copyright (c) 2012, SYSTEC electronik GmbH
 Copyright (c) 2017, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2017, Kalycito Infotech Private Limited.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -63,6 +64,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONFIG_INCLUDE_SDO_ASND
 #define CONFIG_INCLUDE_SDO_RW_MULTIPLE
 #define CONFIG_INCLUDE_MASND
+#define CONFIG_INCLUDE_SOC_TIME_FORWARD
 
 #define CONFIG_DLLCAL_QUEUE                         CIRCBUF_QUEUE
 

--- a/stack/proj/windows/liboplkmn/oplkcfg.h
+++ b/stack/proj/windows/liboplkmn/oplkcfg.h
@@ -12,6 +12,7 @@ on Linux.
 /*------------------------------------------------------------------------------
 Copyright (c) 2012, SYSTEC electronik GmbH
 Copyright (c) 2017, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2017, Kalycito Infotech Private Limited.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -65,6 +66,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONFIG_INCLUDE_SDO_RW_MULTIPLE
 #define CONFIG_INCLUDE_CFM
 #define CONFIG_INCLUDE_PRES_FORWARD
+#define CONFIG_INCLUDE_SOC_TIME_FORWARD
 
 #define CONFIG_DLLCAL_QUEUE                         CIRCBUF_QUEUE
 


### PR DESCRIPTION
Enable SoC timestamp forward feature support for BSD semaphore, Linux
IOCTL, Linux Link to application, Altera C5 SoC, Windows Link to
application, Linux PCIe and Zynq hybrid platforms.

Change-Id: I6a17b017c31ef847f96cf4011b371f2816c4c631