### PR TITLE
 [FIX] Fix SDO over UDP feature in Windows design

### DIFF
--- a/apps/demo_mn_console/windows.cmake
+++ b/apps/demo_mn_console/windows.cmake
@@ -3,6 +3,7 @@
 # Windows definitions for console demo application
 #
 # Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+# Copyright (c) 2017, Kalycito Infotech Private Limited.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -56,6 +57,9 @@ ELSE ()
 ENDIF()
 
 SET(ARCH_LIBRARIES wpcap iphlpapi)
+
+# Windows socket function library
+SET(CMAKE_C_STANDARD_LIBRARIES "${CMAKE_C_STANDARD_LIBRARIES} ws2_32.lib")
 
 ################################################################################
 # Set architecture specific installation files

--- a/stack/proj/windows/liboplkmnapp-pcieintf/oplkcfg.h
+++ b/stack/proj/windows/liboplkmnapp-pcieintf/oplkcfg.h
@@ -11,7 +11,7 @@ application library on Windows which is using the PCIe interface.
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2017, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
-Copyright (c) 2015, Kalycito Infotech Private Limited
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -65,6 +65,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONFIG_INCLUDE_SDO_RW_MULTIPLE
 #define CONFIG_INCLUDE_CFM
 #define CONFIG_INCLUDE_VETH
+#define CONFIG_INCLUDE_SDO_UDP
 
 #define CONFIG_DLLCAL_QUEUE                             IOCTL_QUEUE
 
@@ -101,5 +102,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONFIG_SDO_MAX_CONNECTION_ASND              100
 #define CONFIG_SDO_MAX_CONNECTION_SEQ               100
 #define CONFIG_SDO_MAX_CONNECTION_COM               100
+#define CONFIG_SDO_MAX_CONNECTION_UDP               50
 
 #endif // _INC_oplkcfg_H_

--- a/stack/src/user/sdo/sdoudp-windows.c
+++ b/stack/src/user/sdo/sdoudp-windows.c
@@ -12,6 +12,7 @@ This file contains the implementation of the SDO over UDP protocol for Windows.
 /*------------------------------------------------------------------------------
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
 Copyright (c) 2013, SYSTEC electronic GmbH
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -42,6 +43,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //------------------------------------------------------------------------------
 #include <common/oplkinc.h>
 #include <user/sdoudp.h>
+
+#include <winsock2.h>
+#include <windows.h>
 
 #include <errno.h>
 
@@ -114,20 +118,8 @@ The function initializes the SDO over UDP socket module.
 //------------------------------------------------------------------------------
 tOplkError sdoudp_initSocket(void)
 {
-    INT     error;
-    WSADATA wsa;
-
     OPLK_MEMSET(&instance_l, 0x00, sizeof(instance_l));
 
-    error = WSAStartup(MAKEWORD(2, 0), &wsa);
-    if (error != 0)
-        return kErrorSdoUdpNoSocket;
-
-    // Create critical section for access of instance variables
-    instance_l.pCriticalSection = &instance_l.criticalSection;
-    InitializeCriticalSection(instance_l.pCriticalSection);
-
-    instance_l.threadHandle = 0;
     instance_l.udpSocket = INVALID_SOCKET;
 
     return kErrorOk;
@@ -164,11 +156,21 @@ tOplkError sdoudp_createSocket(tSdoUdpCon* pSdoUdpCon_p)
 {
     struct sockaddr_in  addr;
     INT                 error;
-    BOOL                fTermError;
     ULONG               threadId;
+    WSADATA             wsa;
+    WORD                wVersionRequested;
 
     // Check parameter validity
     ASSERT(pSdoUdpCon_p != NULL);
+
+    wVersionRequested = MAKEWORD(2, 0);
+
+    error = WSAStartup(wVersionRequested, &wsa);
+    if (error != 0)
+    {
+        DEBUG_LVL_SDO_TRACE("%s(): WSAStartup() failed\n", __func__);
+        return kErrorSdoUdpNoSocket;
+    }
 
     instance_l.udpSocket = socket(PF_INET, SOCK_DGRAM, IPPROTO_UDP);
     if (instance_l.udpSocket == INVALID_SOCKET)
@@ -224,7 +226,6 @@ tOplkError sdoudp_closeSocket(void)
 
     if (instance_l.threadHandle != 0)
     {   // listen thread was started -> close old thread
-
         fTermError = TerminateThread(instance_l.threadHandle, 0);
         if (fTermError == FALSE)
             return kErrorSdoUdpThreadError;
@@ -234,13 +235,12 @@ tOplkError sdoudp_closeSocket(void)
 
     if (instance_l.udpSocket != INVALID_SOCKET)
     {
-        error = close(instance_l.udpSocket);
+        error = closesocket(instance_l.udpSocket);
         instance_l.udpSocket = INVALID_SOCKET;
         if (error != 0)
             return kErrorSdoUdpSocketError;
     }
 
-    DeleteCriticalSection(instance_l.pCriticalSection);
     WSACleanup();
 
     return kErrorOk;
@@ -310,10 +310,7 @@ the SDO UDP module.
 //------------------------------------------------------------------------------
 void sdoudp_criticalSection(BOOL fEnable_p)
 {
-    if (fEnable_p)
-        EnterCriticalSection(instance_l.pCriticalSection);
-    else
-        LeaveCriticalSection(instance_l.pCriticalSection);
+    UNUSED_PARAMETER(fEnable_p);
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
 - Resolve compilation issue due to missing library for
   socketwrapper.
 - Enable SDO over UDP feature in oplkcfg.h of windows
   design.
 - Modify the initialization of socketwrapper functionality
   to resolve application crash.

Change-Id: I9536337f3c998ec68243c612aa5b3bb8206a0642

**Known issue:** This pull request will resolve the 'SDO over UDP feature in Windows design' issue. Due to the existing issue with queue corruption #142, long-run test will not be successful. 
 
