### PR TITLE
[FIX] Fix SDO over UDP feature in Windows designs

### DIFF
--- a/apps/demo_mn_console/windows.cmake
+++ b/apps/demo_mn_console/windows.cmake
@@ -3,6 +3,7 @@
 # Windows definitions for console demo application
 #
 # Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+# Copyright (c) 2017, Kalycito Infotech Private Limited.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -55,7 +56,7 @@ ELSE ()
     LINK_DIRECTORIES(${CONTRIB_SOURCE_DIR}/pcap/windows/WpdPack/Lib)
 ENDIF()
 
-SET(ARCH_LIBRARIES wpcap iphlpapi)
+SET(ARCH_LIBRARIES wpcap iphlpapi ws2_32.lib)
 
 ################################################################################
 # Set architecture specific installation files

--- a/stack/proj/windows/liboplkmnapp-kernelintf/CMakeLists.txt
+++ b/stack/proj/windows/liboplkmnapp-kernelintf/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # CMake file of openPOWERLINK application MN library with kernelspace interface
 #
-# Copyright (c) 2015, Kalycito Infotech Private Limited
+# Copyright (c) 2017, Kalycito Infotech Private Limited
 # Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
 # All rights reserved.
 #
@@ -44,6 +44,7 @@ ENDIF()
 SET (LIB_SOURCES
      ${USER_SOURCES}
      ${USER_MN_SOURCES}
+     ${SDO_WINDOWS_SOURCES}
      ${CTRL_UCAL_WINDOWSIOCTL_SOURCES}
      ${DLL_UCAL_WINDOWSIOCTL_SOURCES}
      ${ERRHND_UCAL_WINDOWSIOCTL_SOURCES}

--- a/stack/proj/windows/liboplkmnapp-kernelintf/oplkcfg.h
+++ b/stack/proj/windows/liboplkmnapp-kernelintf/oplkcfg.h
@@ -11,7 +11,7 @@ application library on Windows which is using the kernelspace interface.
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2017, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
-Copyright (c) 2015, Kalycito Infotech Private Limited
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -66,6 +66,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONFIG_INCLUDE_CFM
 #define CONFIG_INCLUDE_PRES_FORWARD
 #define CONFIG_INCLUDE_VETH
+#define CONFIG_INCLUDE_SDO_UDP
 #define CONFIG_DLLCAL_QUEUE                             IOCTL_QUEUE
 
 #define CONFIG_VETH_SET_DEFAULT_GATEWAY                 FALSE

--- a/stack/proj/windows/liboplkmnapp-pcieintf/oplkcfg.h
+++ b/stack/proj/windows/liboplkmnapp-pcieintf/oplkcfg.h
@@ -11,7 +11,7 @@ application library on Windows which is using the PCIe interface.
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2017, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
-Copyright (c) 2015, Kalycito Infotech Private Limited
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -65,6 +65,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONFIG_INCLUDE_SDO_RW_MULTIPLE
 #define CONFIG_INCLUDE_CFM
 #define CONFIG_INCLUDE_VETH
+#define CONFIG_INCLUDE_SDO_UDP
 
 #define CONFIG_DLLCAL_QUEUE                             IOCTL_QUEUE
 
@@ -101,5 +102,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONFIG_SDO_MAX_CONNECTION_ASND              100
 #define CONFIG_SDO_MAX_CONNECTION_SEQ               100
 #define CONFIG_SDO_MAX_CONNECTION_COM               100
+#define CONFIG_SDO_MAX_CONNECTION_UDP               50
 
 #endif // _INC_oplkcfg_H_


### PR DESCRIPTION
 - Resolve compilation issue due to missing library for
   socketwrapper.
 - Enable SDO over UDP feature in oplkcfg.h of Windows
   designs(PCIe and NDIS).
 - Modify the initialization of socketwrapper functionality
   and remove critical section to avoid application crash.
 - Add "Windows SDO sources" in CMakeLists.txt for
   Windows NDIS design.

This pull request overrides the previous pull request #291 