### PR TITLE
[FEATURE] Add SoC timestamp forwarding feature in Windows PCIe design

### DIFF
--- a/drivers/windows/drv_ndis_pcie/drvintf.c
+++ b/drivers/windows/drv_ndis_pcie/drvintf.c
@@ -16,7 +16,7 @@ direct access for specific shared memory regions to the user application.
 *******************************************************************************/
 
 /*------------------------------------------------------------------------------
-Copyright (c) 2015, Kalycito Infotech Private Limited
+Copyright (c) 2017, Kalycito Infotech Private Limited
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
 All rights reserved.
 
@@ -67,10 +67,13 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //------------------------------------------------------------------------------
 // module global vars
 //------------------------------------------------------------------------------
-#define DUALPROCSHM_BUFF_ID_ERRHDLR 12
-#define DUALPROCSHM_BUFF_ID_PDO     13
-#define BENCHMARK_OFFSET            0x00001000  //TODO: Get this value from PCIe header files
-#define DPSHM_ENABLE_TIMEOUT_SEC    10          // wait for dpshm interface enable time out
+#define DUALPROCSHM_BUFF_ID_ERRHDLR  12
+#define DUALPROCSHM_BUFF_ID_PDO      13
+#define BENCHMARK_OFFSET             0x00001000  //TODO: Get this value from PCIe header files
+#define DPSHM_ENABLE_TIMEOUT_SEC     10          // wait for dpshm interface enable time out
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+#define DUALPROCSHM_BUFF_ID_TIMESYNC 14
+#endif
 
 //------------------------------------------------------------------------------
 // global function prototypes
@@ -939,6 +942,58 @@ size_t drv_getFileBufferSize(void)
 {
     return CONFIG_CTRL_FILE_CHUNK_SIZE;
 }
+
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+//------------------------------------------------------------------------------
+/**
+\brief  Get timesync memory offset
+
+Retrieves the SoC memory offset from the dualprocshm library and shares it
+with user application.
+
+\param[out]     pSocMemOffs_p       Pointer to SoC memory offset value.
+\param[in]      socMemSize_p        Size of the SoC memory.
+
+\return The function returns a tOplkError error code.
+
+\ingroup module_driver_ndispcie
+*/
+//------------------------------------------------------------------------------
+tOplkError drv_getTimesyncMem(UINT32* pSocMemOffs_p,
+                              size_t socMemSize_p)
+{
+    ptrdiff_t       offset;
+    void*           pMem = NULL;
+    UINT8*          pBar0 = NULL;
+    tDualprocReturn dualRet = kDualprocSuccessful;
+
+    pBar0 = (UINT8*)ndis_getBarAddr(OPLK_PCIEBAR_SHM);
+
+    if (!drvInstance_l.fDriverActive || (pBar0 == NULL) || (pSocMemOffs_p == NULL))
+        return kErrorNoResource;
+
+    dualRet = dualprocshm_getMemory(drvInstance_l.pDualProcDrvInst,
+                                    DUALPROCSHM_BUFF_ID_TIMESYNC,
+                                    &pMem,
+                                    &socMemSize_p,
+                                    FALSE);
+
+    if (dualRet != kDualprocSuccessful)
+    {
+        DEBUG_LVL_ERROR_TRACE("%s() Couldn't allocate SoC buffer (0x%X)\n",
+                              __func__,
+                              dualRet);
+        return kErrorNoResource;
+    }
+
+    offset = (UINT8*)pMem - pBar0;
+    *pSocMemOffs_p = (UINT32)offset;
+
+    DEBUG_LVL_ALWAYS_TRACE("%s() Timesync shared memory offset is %x\n", __func__, offset);
+
+    return kErrorOk;
+}
+#endif
 
 //============================================================================//
 //            P R I V A T E   F U N C T I O N S                               //

--- a/drivers/windows/drv_ndis_pcie/drvintf.h
+++ b/drivers/windows/drv_ndis_pcie/drvintf.h
@@ -9,7 +9,7 @@ Driver interface for the kernel daemon - Header file
 *******************************************************************************/
 
 /*------------------------------------------------------------------------------
-Copyright (c) 2015, Kalycito Infotech Private Limited
+Copyright (c) 2017, Kalycito Infotech Private Limited
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
 All rights reserved.
 
@@ -95,6 +95,10 @@ tOplkError drv_mapKernelMem(void** ppKernelMem_p,
 void       drv_unmapKernelMem(void* pUserMem_p);
 tOplkError drv_writeFileBuffer(const tIoctlFileChunk* pIoctlFileChunk_p);
 size_t     drv_getFileBufferSize(void);
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+tOplkError drv_getTimesyncMem(UINT32* pTimesyncMemOffs_p,
+                              size_t socMemSize_p);
+#endif
 
 #ifdef __cplusplus
 }

--- a/drivers/windows/drv_ndis_pcie/main.c
+++ b/drivers/windows/drv_ndis_pcie/main.c
@@ -11,7 +11,7 @@ implementation for PCIe device.
 *******************************************************************************/
 
 /*------------------------------------------------------------------------------
-Copyright (c) 2015, Kalycito Infotech Private Limited
+Copyright (c) 2017, Kalycito Infotech Private Limited
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
 All rights reserved.
 
@@ -636,6 +636,22 @@ NTSTATUS powerlinkIoctl(PDEVICE_OBJECT pDeviceObject_p,
             status = STATUS_SUCCESS;
             break;
         }
+
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+       case PLK_CMD_SOC_GET_MEM:
+        {
+            tSocMem* pSocMem = (tSocMem*)pIrp_p->AssociatedIrp.SystemBuffer;
+
+            oplkRet = drv_getTimesyncMem(&pSocMem->socMemOffset, pSocMem->socMemSize);
+            if (oplkRet != kErrorOk)
+                pIrp_p->IoStatus.Information = 0; // return size zero to indicate failure
+            else
+                pIrp_p->IoStatus.Information = sizeof(tSocMem);
+
+            status = STATUS_SUCCESS;
+            break;
+        }
+#endif
 
         default:
             DEBUG_LVL_ERROR_TRACE("PLK: - Invalid cmd (cmd=%d)\n",

--- a/stack/include/common/driver-windows.h
+++ b/stack/include/common/driver-windows.h
@@ -9,7 +9,7 @@ Windows kernel driver.
 *******************************************************************************/
 
 /*------------------------------------------------------------------------------
-Copyright (c) 2015, Kalycito Infotech Private Limited
+Copyright (c) 2017, Kalycito Infotech Private Limited
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
 All rights reserved.
 
@@ -86,6 +86,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                                 CTL_CODE(PLK_IO_TYPE, 0x913, METHOD_BUFFERED, FILE_ANY_ACCESS)
 #define PLK_CMD_CTRL_GET_FILE_BUFFER_SIZE \
                                 CTL_CODE(PLK_IO_TYPE, 0x914, METHOD_BUFFERED, FILE_ANY_ACCESS)
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+#define PLK_CMD_SOC_GET_MEM     CTL_CODE(PLK_IO_TYPE, 0x915, METHOD_BUFFERED, FILE_ANY_ACCESS)
+#endif
 
 //------------------------------------------------------------------------------
 // typedef

--- a/stack/include/common/driver.h
+++ b/stack/include/common/driver.h
@@ -121,6 +121,20 @@ typedef struct
     UINT32                  size;           ///< Size of the shared memory
 } tMemStruc;
 
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+/**
+\brief SoC memory structure
+
+The structure is used to retrieve the SoC memory allocated by openPOWERLINK
+kernel stack and mapped into user virtual address space.
+*/
+typedef struct
+{
+    size_t                  socMemSize;     ///< Size of SoC memory to be allocated and mapped
+    UINT32                  socMemOffset;   ///< Offset of SoC memory returned by kernel
+} tSocMem;
+#endif
+
 //------------------------------------------------------------------------------
 // function prototypes
 //------------------------------------------------------------------------------

--- a/stack/src/user/timesync/timesyncucal-winioctl.c
+++ b/stack/src/user/timesync/timesyncucal-winioctl.c
@@ -5,13 +5,15 @@
 \brief  Sync implementation for the user CAL timesync module using Windows IOCTL
 
 This files implements the user CAL timesync module for synchronization using
-Windows IOCTL for communication between user and kernel layer of the stack.
+Windows IOCTL for communication between user and kernel layer of the stack. In
+addition SoC timestamp forwarding feature implementation is done by creating
+a shared memory for the user and kernel.
 
 \ingroup module_timesyncucal
 *******************************************************************************/
 
 /*------------------------------------------------------------------------------
-Copyright (c) 2015, Kalycito Infotech Private Limited
+Copyright (c) 2017, Kalycito Infotech Private Limited
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
 All rights reserved.
 
@@ -81,9 +83,12 @@ The structure holds the global parameters for PDO synchronization module.
 */
 typedef struct
 {
-    OPLK_FILE_HANDLE    hGlobalFileHandle;        ///< Global file handle to POWERLINK driver
-    HANDLE              hSyncFileHandle;          ///< File handle to driver for synchronization
-    BOOL                fIntialized;              ///< Flag to mark module initialization
+    OPLK_FILE_HANDLE       hGlobalFileHandle;        ///< Global file handle to POWERLINK driver
+    HANDLE                 hSyncFileHandle;          ///< File handle to driver for synchronization
+    BOOL                   fIntialized;              ///< Flag to mark module initialization
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+    tTimesyncSharedMemory* pSharedMemory;            ///< Pointer to timesync shared memory
+#endif
 } tTimesyncuCalInstance;
 
 //------------------------------------------------------------------------------
@@ -94,6 +99,10 @@ static tTimesyncuCalInstance timesyncuInstance_l;
 //------------------------------------------------------------------------------
 // local function prototypes
 //------------------------------------------------------------------------------
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+static tOplkError getTimesyncShm(void);
+static tOplkError releaseTimesyncShm(void);
+#endif
 
 //============================================================================//
 //            P U B L I C   F U N C T I O N S                                 //
@@ -142,6 +151,16 @@ tOplkError timesyncucal_init(tSyncCb pfnSyncCb_p)
     }
 
     timesyncuInstance_l.fIntialized = TRUE;
+
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+    if (getTimesyncShm() != kErrorOk)
+    {
+        DEBUG_LVL_ERROR_TRACE("%s() Couldn't get timesync shared memory!\n",
+                              __func__);
+        return kErrorNoResource;
+    }
+#endif
+
     return kErrorOk;
 }
 
@@ -157,6 +176,14 @@ The function cleans up the user CAL timesync module
 void timesyncucal_exit(void)
 {
     ULONG    bytesReturned;
+
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+    if (releaseTimesyncShm() != kErrorOk)
+    {
+        DEBUG_LVL_ERROR_TRACE("%s() SoC Timestamp shm could not be released\n",
+                              __func__);
+    }
+#endif
 
     // Clean resources acquired in kernel driver for synchronization.
     if (!DeviceIoControl(timesyncuInstance_l.hGlobalFileHandle,
@@ -215,10 +242,116 @@ tOplkError timesyncucal_waitSyncEvent(ULONG timeout_p)
     return kErrorOk;
 }
 
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+//------------------------------------------------------------------------------
+/**
+\brief  Get timesync shared memory
+
+The function returns the reference to the timesync shared memory.
+
+\return The function returns a pointer to the timesync shared memory.
+
+\ingroup module_timesyncucal
+*/
+//------------------------------------------------------------------------------
+tTimesyncSharedMemory* timesyncucal_getSharedMemory(void)
+{
+    return timesyncuInstance_l.pSharedMemory;
+}
+
 //============================================================================//
 //            P R I V A T E   F U N C T I O N S                               //
 //============================================================================//
 /// \name Private Functions
 /// \{
+
+//------------------------------------------------------------------------------
+/**
+\brief  Get timesync shared memory
+
+The function gets the available SoC timesync shared memory using
+Windows IOCTL and remaps the shared memory into user space.
+
+\return The function returns a tOplkError error code.
+*/
+//------------------------------------------------------------------------------
+static tOplkError getTimesyncShm(void)
+{
+    BOOL        fIoctlRet = FALSE;
+    ULONG       bytesReturned = 0;
+    tSocMem     inSocTimesyncMem;
+    tSocMem     outSocTimesyncMem;
+    tOplkError  ret = kErrorOk;
+ #ifdef CONFIG_PCIE
+    void*       pSocTimesyncMemOut;
+#endif
+
+    if (timesyncuInstance_l.hGlobalFileHandle == NULL)
+        return kErrorNoResource;
+
+    inSocTimesyncMem.socMemSize = sizeof(tTimesyncSharedMemory);
+
+    fIoctlRet = DeviceIoControl(timesyncuInstance_l.hGlobalFileHandle,
+                                PLK_CMD_SOC_GET_MEM,
+                                &inSocTimesyncMem,
+                                sizeof(tSocMem),
+                                &outSocTimesyncMem,
+                                sizeof(tSocMem),
+                                &bytesReturned,
+                                NULL);
+
+    if (!fIoctlRet || (bytesReturned == 0) ||
+        (outSocTimesyncMem.socMemOffset == 0))
+    {
+        DEBUG_LVL_ERROR_TRACE("%s(): Error in IOCTL %d\n",
+                              __func__,
+                              GetLastError());
+        timesyncuInstance_l.pSharedMemory = NULL;
+        return kErrorNoResource;
+    }
+
+#ifdef CONFIG_PCIE
+    ret = ctrlucal_getMappedMem(outSocTimesyncMem.socMemOffset,
+                                (UINT32)outSocTimesyncMem.socMemSize,
+                                &(UINT8*)pSocTimesyncMemOut);
+
+    if ((ret != kErrorOk) || (pSocTimesyncMemOut == NULL))
+    {
+        DEBUG_LVL_ERROR_TRACE("%s() Couldn't get timesync shared memory.\n",
+                              __func__);
+        return ret;
+    }
+
+    timesyncuInstance_l.pSharedMemory = pSocTimesyncMemOut;
+#else
+    if (outSocTimesyncMem.socMemSize > inSocTimesyncMem.socMemSize)
+        return kErrorNoResource;
+
+    (UINT32)timesyncuInstance_l.pSharedMemory = outSocTimesyncMem.socMemOffset;
+#endif
+
+    return ret;
+}
+
+//------------------------------------------------------------------------------
+/**
+\brief  Release timesync shared memory
+
+The function releases the remapped timesync shared memory.
+
+\return The function returns a tOplkError error code.
+*/
+//------------------------------------------------------------------------------
+static tOplkError releaseTimesyncShm(void)
+{
+    if (timesyncuInstance_l.hGlobalFileHandle == NULL)
+        return kErrorNoResource;
+
+    if (timesyncuInstance_l.pSharedMemory != NULL)
+        timesyncuInstance_l.pSharedMemory = NULL;
+
+    return kErrorOk;
+}
+#endif
 
 /// \}


### PR DESCRIPTION
 - This commit introduces the SoC time forwarding capability to the
   Windows PCIe design using a shared memory.
 - Create a shared memory between kernel and user to hold SoC time
   stamps.
 - Release the shared memory during exit.

Change-Id: Icbccd508eea925c9e38c153f1ce02d4e48110bea