### PR TITLE
[TASK] Enable SoC timestamp forward feature for Windows PCIe and NDIS

### DIFF
--- a/drivers/windows/drv_ndis_intermediate/proj/mn/oplkcfg.h
+++ b/drivers/windows/drv_ndis_intermediate/proj/mn/oplkcfg.h
@@ -11,6 +11,7 @@ This file contains the configuration options for the openPOWERLINK kernel module
 /*------------------------------------------------------------------------------
 Copyright (c) 2012, SYSTEC electronik GmbH
 Copyright (c) 2014, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -61,6 +62,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONFIG_INCLUDE_VETH
 #define CONFIG_INCLUDE_CFM
 #define CONFIG_INCLUDE_PRES_FORWARD
+#define CONFIG_INCLUDE_SOC_TIME_FORWARD
 
 #define CONFIG_DLLCAL_QUEUE                         CIRCBUF_QUEUE
 

--- a/drivers/windows/drv_ndis_pcie/proj/mn/oplkcfg.h
+++ b/drivers/windows/drv_ndis_pcie/proj/mn/oplkcfg.h
@@ -10,7 +10,7 @@ interface module.
 *******************************************************************************/
 
 /*------------------------------------------------------------------------------
-Copyright (c) 2015, Kalycito Infotech Private Limited
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -50,5 +50,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 #define CONFIG_INCLUDE_VETH
+#define CONFIG_INCLUDE_SOC_TIME_FORWARD
 
 #endif // _INC_oplkcfg_H_

--- a/stack/proj/windows/liboplkmnapp-kernelintf/oplkcfg.h
+++ b/stack/proj/windows/liboplkmnapp-kernelintf/oplkcfg.h
@@ -11,7 +11,7 @@ application library on Windows which is using the kernelspace interface.
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2017, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
-Copyright (c) 2015, Kalycito Infotech Private Limited
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -67,6 +67,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONFIG_INCLUDE_PRES_FORWARD
 #define CONFIG_INCLUDE_VETH
 #define CONFIG_DLLCAL_QUEUE                             IOCTL_QUEUE
+#define CONFIG_INCLUDE_SOC_TIME_FORWARD
 
 #define CONFIG_VETH_SET_DEFAULT_GATEWAY                 FALSE
 

--- a/stack/proj/windows/liboplkmnapp-pcieintf/oplkcfg.h
+++ b/stack/proj/windows/liboplkmnapp-pcieintf/oplkcfg.h
@@ -11,7 +11,7 @@ application library on Windows which is using the PCIe interface.
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2017, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
-Copyright (c) 2015, Kalycito Infotech Private Limited
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -65,6 +65,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONFIG_INCLUDE_SDO_RW_MULTIPLE
 #define CONFIG_INCLUDE_CFM
 #define CONFIG_INCLUDE_VETH
+#define CONFIG_INCLUDE_SOC_TIME_FORWARD
 
 #define CONFIG_DLLCAL_QUEUE                             IOCTL_QUEUE
 


### PR DESCRIPTION
Enable SoC timestamp forward feature support for Windows PCIe and
Windows NDIS intermediate platforms.

Change-Id: Ib17c937d270de25007f27115643ddcd97d1b77fc