### PR TITLE
[FEATURE] Add SoC timestamp forwarding feature in Windows NDIS design

### DIFF
--- a/drivers/windows/drv_ndis_intermediate/drvintf.c
+++ b/drivers/windows/drv_ndis_intermediate/drvintf.c
@@ -12,7 +12,7 @@ suitable structure before forwarding to a specific kernel stack module.
 *******************************************************************************/
 
 /*------------------------------------------------------------------------------
-Copyright (c) 2015, Kalycito Infotech Private Limited
+Copyright (c) 2017, Kalycito Infotech Private Limited
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
 All rights reserved.
 
@@ -49,6 +49,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <kernel/dllkcal.h>
 #include <kernel/pdokcal.h>
 #include <kernel/errhndk.h>
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+#include <kernel/timesynckcal.h>
+#endif
 
 //============================================================================//
 //            G L O B A L   D E F I N I T I O N S                             //
@@ -95,7 +98,10 @@ typedef struct
 //------------------------------------------------------------------------------
 // local vars
 //------------------------------------------------------------------------------
-static tMemInfo pdoMemInfo_l;
+static tMemInfo pdoMemInfo_l;       // PDO memory Instance
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+static tMemInfo socMemInfo_l;       // SoC memory isntance
+#endif
 
 //------------------------------------------------------------------------------
 // local function prototypes
@@ -457,6 +463,118 @@ void drv_unMapPdoMem(void* pMem_p,
     pdoMemInfo_l.pUserVa = NULL;
 }
 
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+//------------------------------------------------------------------------------
+/**
+\brief  Map SoC shared memory
+
+This routine maps the SoC memory allocated in the kernel layer of the openPOWERLINK
+stack. This allows user stack to access the SoC memory directly.
+
+\param[out]     pUserMem_p          Pointer to the shared memory segment in user space.
+\param[in,out]  pMemSize_p          Pointer to size of SoC memory.
+
+\return The function returns a tOplkError error code.
+
+\ingroup module_driver_ndisim
+*/
+//------------------------------------------------------------------------------
+tOplkError drv_mapSocMem(UINT32* pUserMem_p,
+                         size_t* pMemSize_p)
+{
+    if (pUserMem_p == NULL || pMemSize_p == NULL)
+    {
+        DEBUG_LVL_ERROR_TRACE("%s() Invalid pointer !\n");
+        return kErrorNoResource;
+    }
+
+    // Get SoC memory
+    socMemInfo_l.pKernelVa = timesynckcal_getSharedMemory();
+    if (socMemInfo_l.pKernelVa == NULL)
+    {
+        DEBUG_LVL_ERROR_TRACE("%s() Timesync shared memory is NULL !", __func__);
+        return kErrorNoResource;
+    }
+
+    // Set SoC memory size
+    socMemInfo_l.memSize = sizeof(tTimesyncSharedMemory);
+
+    if (*pMemSize_p > socMemInfo_l.memSize)
+    {
+        DEBUG_LVL_ERROR_TRACE("%s() Higher memory requested (Kernel-%d User-%d) !\n",
+                              __func__,
+                              socMemInfo_l.memSize,
+                              *pMemSize_p);
+        *pMemSize_p = 0;
+        return kErrorNoResource;
+    }
+
+    // Allocate new MDL pointing to SoC memory
+    socMemInfo_l.pMdl = IoAllocateMdl(socMemInfo_l.pKernelVa,
+                                      socMemInfo_l.memSize,
+                                      FALSE,
+                                      FALSE,
+                                      NULL);
+
+    if (socMemInfo_l.pMdl == NULL)
+    {
+        DEBUG_LVL_ERROR_TRACE("%s() Error allocating MDL !\n", __func__);
+        return kErrorNoResource;
+    }
+
+    // Update the MDL with physical addresses
+    MmBuildMdlForNonPagedPool(socMemInfo_l.pMdl);
+
+    // Maps the physical pages that are described by an MDL to a virtual address
+    socMemInfo_l.pUserVa = MmMapLockedPagesSpecifyCache(socMemInfo_l.pMdl,    // MDL
+                                                        UserMode,             // Mode
+                                                        MmCached,             // Caching
+                                                        NULL,                 // Address
+                                                        FALSE,                // Bug-check?
+                                                        NormalPagePriority);  // Priority
+
+    if (socMemInfo_l.pUserVa == NULL)
+    {
+        MmUnmapLockedPages(socMemInfo_l.pUserVa, socMemInfo_l.pMdl);
+        IoFreeMdl(socMemInfo_l.pMdl);
+        DEBUG_LVL_ERROR_TRACE("%s() Error mapping MDL !\n", __func__);
+        return kErrorNoResource;
+    }
+
+    *pUserMem_p = (UINT32)socMemInfo_l.pUserVa;
+    *pMemSize_p = socMemInfo_l.memSize;
+
+    DEBUG_LVL_ALWAYS_TRACE("Mapped SoC memory info U:%p K:%p size %x",
+                           socMemInfo_l.pUserVa,
+                           socMemInfo_l.pKernelVa,
+                           socMemInfo_l.memSize);
+
+    return kErrorOk;
+}
+
+//------------------------------------------------------------------------------
+/**
+\brief  Unmap SoC shared memory
+
+Unmap the SoC memory shared with the user layer.
+
+\ingroup module_driver_ndisim
+*/
+//------------------------------------------------------------------------------
+void drv_unMapSocMem(void)
+{
+    if (socMemInfo_l.pMdl == NULL)
+        DEBUG_LVL_ERROR_TRACE("%s() MDL already deleted !\n", __func__);
+
+    if (socMemInfo_l.pUserVa != NULL)
+    {
+        MmUnmapLockedPages(socMemInfo_l.pUserVa, socMemInfo_l.pMdl);
+        IoFreeMdl(socMemInfo_l.pMdl);
+    }
+
+    socMemInfo_l.pUserVa = NULL;
+}
+#endif
 
 //============================================================================//
 //            P R I V A T E   F U N C T I O N S                               //

--- a/drivers/windows/drv_ndis_intermediate/drvintf.h
+++ b/drivers/windows/drv_ndis_intermediate/drvintf.h
@@ -9,7 +9,7 @@ Driver interface for the kernel daemon - Header file
 *******************************************************************************/
 
 /*------------------------------------------------------------------------------
-Copyright (c) 2015, Kalycito Infotech Private Limited
+Copyright (c) 2017, Kalycito Infotech Private Limited
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
 All rights reserved.
 
@@ -87,6 +87,11 @@ tOplkError drv_mapPdoMem(void** ppKernelMem_p,
                          size_t* pMemSize_p);
 void       drv_unMapPdoMem(void* pMem_p,
                            size_t memSize_p);
+#if defined(CONFIG_INCLUDE_SOC_TIME_FORWARD)
+tOplkError drv_mapSocMem(UINT32* ppUserMem_p,
+                         size_t* pMemSize_p);
+void       drv_unMapSocMem(void);
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
 - This commit introduces the SoC time forwarding capability to the
   Windows NDIS intermediate design using a shared memory.
 - Create a shared memory between kernel and user to hold SoC time
   stamps.
 - Release the shared memory during exit.

Change-Id: I0250a79da55315f3e3637ceb4ebd4fcbddf16ba8