### PR TITLE
[FIX] Fix SDO over UDP feature in Windows designs

### DIFF
--- a/apps/demo_mn_console/windows.cmake
+++ b/apps/demo_mn_console/windows.cmake
@@ -2,7 +2,8 @@
 #
 # Windows definitions for console demo application
 #
-# Copyright (c) 20176, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+# Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+# Copyright (c) 2017, Kalycito Infotech Private Limited.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -53,7 +54,11 @@ ELSE ()
     LINK_DIRECTORIES(${CONTRIB_SOURCE_DIR}/pcap/windows/WpdPack/Lib)
 ENDIF()
 
-SET(ARCH_LIBRARIES wpcap iphlpapi)
+IF (CFG_KERNEL_STACK_PCIE OR CFG_KERNEL_STACK_KERNEL_MODULE)
+    SET(ARCH_LIBRARIES iphlpapi ws2_32.lib)
+ELSE ()
+    SET(ARCH_LIBRARIES wpcap iphlpapi)
+ENDIF()
 
 ################################################################################
 # Set architecture specific installation files

--- a/stack/proj/windows/liboplkmnapp-kernelintf/CMakeLists.txt
+++ b/stack/proj/windows/liboplkmnapp-kernelintf/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # CMake file of openPOWERLINK application MN library with kernelspace interface
 #
-# Copyright (c) 2015, Kalycito Infotech Private Limited
+# Copyright (c) 2017, Kalycito Infotech Private Limited
 # Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
 # All rights reserved.
 #
@@ -44,6 +44,7 @@ ENDIF()
 SET (LIB_SOURCES
      ${USER_SOURCES}
      ${USER_MN_SOURCES}
+     ${SDO_WINDOWS_SOURCES}
      ${CTRL_UCAL_WINDOWSIOCTL_SOURCES}
      ${DLL_UCAL_WINDOWSIOCTL_SOURCES}
      ${ERRHND_UCAL_WINDOWSIOCTL_SOURCES}

--- a/stack/proj/windows/liboplkmnapp-kernelintf/oplkcfg.h
+++ b/stack/proj/windows/liboplkmnapp-kernelintf/oplkcfg.h
@@ -11,7 +11,7 @@ application library on Windows which is using the kernelspace interface.
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2017, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
-Copyright (c) 2015, Kalycito Infotech Private Limited
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -66,6 +66,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONFIG_INCLUDE_CFM
 #define CONFIG_INCLUDE_PRES_FORWARD
 #define CONFIG_INCLUDE_VETH
+#define CONFIG_INCLUDE_SDO_UDP
 #define CONFIG_DLLCAL_QUEUE                             IOCTL_QUEUE
 
 #define CONFIG_VETH_SET_DEFAULT_GATEWAY                 FALSE

--- a/stack/proj/windows/liboplkmnapp-pcieintf/oplkcfg.h
+++ b/stack/proj/windows/liboplkmnapp-pcieintf/oplkcfg.h
@@ -11,7 +11,7 @@ application library on Windows which is using the PCIe interface.
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2017, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
-Copyright (c) 2015, Kalycito Infotech Private Limited
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -65,6 +65,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONFIG_INCLUDE_SDO_RW_MULTIPLE
 #define CONFIG_INCLUDE_CFM
 #define CONFIG_INCLUDE_VETH
+#define CONFIG_INCLUDE_SDO_UDP
 
 #define CONFIG_DLLCAL_QUEUE                             IOCTL_QUEUE
 
@@ -101,5 +102,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONFIG_SDO_MAX_CONNECTION_ASND              100
 #define CONFIG_SDO_MAX_CONNECTION_SEQ               100
 #define CONFIG_SDO_MAX_CONNECTION_COM               100
+#define CONFIG_SDO_MAX_CONNECTION_UDP               50
 
 #endif // _INC_oplkcfg_H_

--- a/stack/src/user/sdo/sdoudp-windows.c
+++ b/stack/src/user/sdo/sdoudp-windows.c
@@ -12,6 +12,7 @@ This file contains the implementation of the SDO over UDP protocol for Windows.
 /*------------------------------------------------------------------------------
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
 Copyright (c) 2013, SYSTEC electronic GmbH
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -42,6 +43,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //------------------------------------------------------------------------------
 #include <common/oplkinc.h>
 #include <user/sdoudp.h>
+
+#include <winsock2.h>
+#include <windows.h>
 
 #include <errno.h>
 
@@ -74,15 +78,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //------------------------------------------------------------------------------
 // local types
 //------------------------------------------------------------------------------
-typedef DWORD tThreadResult;
 typedef LPVOID tThreadArg;
 
 typedef struct
 {
     SOCKET                      udpSocket;
     HANDLE                      threadHandle;
-    LPCRITICAL_SECTION          pCriticalSection;
-    CRITICAL_SECTION            criticalSection;
     BOOL                        fStopThread;
 } tSdoUdpSocketInstance;
 
@@ -95,7 +96,7 @@ static tSdoUdpSocketInstance    instance_l;
 // local function prototypes
 //------------------------------------------------------------------------------
 static void          receiveFromSocket(const tSdoUdpSocketInstance* pInstance_p);
-static tThreadResult sdoUdpThread(tThreadArg pArg_p);
+static DWORD WINAPI  sdoUdpThread(tThreadArg pArg_p);
 
 //============================================================================//
 //            P U B L I C   F U N C T I O N S                                 //
@@ -114,20 +115,8 @@ The function initializes the SDO over UDP socket module.
 //------------------------------------------------------------------------------
 tOplkError sdoudp_initSocket(void)
 {
-    INT     error;
-    WSADATA wsa;
-
     OPLK_MEMSET(&instance_l, 0x00, sizeof(instance_l));
 
-    error = WSAStartup(MAKEWORD(2, 0), &wsa);
-    if (error != 0)
-        return kErrorSdoUdpNoSocket;
-
-    // Create critical section for access of instance variables
-    instance_l.pCriticalSection = &instance_l.criticalSection;
-    InitializeCriticalSection(instance_l.pCriticalSection);
-
-    instance_l.threadHandle = 0;
     instance_l.udpSocket = INVALID_SOCKET;
 
     return kErrorOk;
@@ -164,11 +153,21 @@ tOplkError sdoudp_createSocket(tSdoUdpCon* pSdoUdpCon_p)
 {
     struct sockaddr_in  addr;
     INT                 error;
-    BOOL                fTermError;
     ULONG               threadId;
+    WSADATA             wsa;
+    WORD                wVersionRequested;
 
     // Check parameter validity
     ASSERT(pSdoUdpCon_p != NULL);
+
+    wVersionRequested = MAKEWORD(2, 0);
+
+    error = WSAStartup(wVersionRequested, &wsa);
+    if (error != 0)
+    {
+        DEBUG_LVL_SDO_TRACE("%s(): WSAStartup() failed\n", __func__);
+        return kErrorSdoUdpNoSocket;
+    }
 
     instance_l.udpSocket = socket(PF_INET, SOCK_DGRAM, IPPROTO_UDP);
     if (instance_l.udpSocket == INVALID_SOCKET)
@@ -224,7 +223,6 @@ tOplkError sdoudp_closeSocket(void)
 
     if (instance_l.threadHandle != 0)
     {   // listen thread was started -> close old thread
-
         fTermError = TerminateThread(instance_l.threadHandle, 0);
         if (fTermError == FALSE)
             return kErrorSdoUdpThreadError;
@@ -234,13 +232,12 @@ tOplkError sdoudp_closeSocket(void)
 
     if (instance_l.udpSocket != INVALID_SOCKET)
     {
-        error = close(instance_l.udpSocket);
+        error = closesocket(instance_l.udpSocket);
         instance_l.udpSocket = INVALID_SOCKET;
         if (error != 0)
             return kErrorSdoUdpSocketError;
     }
 
-    DeleteCriticalSection(instance_l.pCriticalSection);
     WSACleanup();
 
     return kErrorOk;
@@ -310,10 +307,7 @@ the SDO UDP module.
 //------------------------------------------------------------------------------
 void sdoudp_criticalSection(BOOL fEnable_p)
 {
-    if (fEnable_p)
-        EnterCriticalSection(instance_l.pCriticalSection);
-    else
-        LeaveCriticalSection(instance_l.pCriticalSection);
+    UNUSED_PARAMETER(fEnable_p);
 }
 
 //------------------------------------------------------------------------------
@@ -401,7 +395,7 @@ UDP socket and calls receiveFromSocket() if data is available.
 \return The function returns a thread exit code. It returns always NULL (0).
 */
 //------------------------------------------------------------------------------
-static tThreadResult sdoUdpThread(tThreadArg pArg_p)
+static DWORD WINAPI sdoUdpThread(tThreadArg pArg_p)
 {
     const tSdoUdpSocketInstance*    pInstance;
     fd_set                          readFds;
@@ -418,7 +412,7 @@ static tThreadResult sdoUdpThread(tThreadArg pArg_p)
         FD_ZERO(&readFds);
         FD_SET(pInstance->udpSocket, &readFds);
 
-        result = select(pInstance->udpSocket + 1,
+        result = select((int)pInstance->udpSocket + 1,
                         &readFds,
                         NULL,
                         NULL,


### PR DESCRIPTION
 - Resolve compilation issue due to missing library for
   socketwrapper.
 - Enable SDO over UDP feature in oplkcfg.h of Windows
   designs(PCIe and NDIS).
 - Modify the initialization of socketwrapper functionality
   and remove critical section to avoid application crash.
 - Add "Windows SDO sources" in CMakeLists.txt for
   Windows NDIS design.
 - Resolve stack compilation issue in 32 bit Windows system.
 - Handle library selection between Kernel and pcap designs
   in windows.cmake file.

Change-Id: If9fe22286393e4496875ea1b57314957afe9fddd