### PR TITLE
[FIX] Fix data type definition in Windows designs for 64 bit systems

### DIFF
--- a/drivers/windows/drv_ndis_pcie/drvintf.c
+++ b/drivers/windows/drv_ndis_pcie/drvintf.c
@@ -16,7 +16,7 @@ direct access for specific shared memory regions to the user application.
 *******************************************************************************/
 
 /*------------------------------------------------------------------------------
-Copyright (c) 2015, Kalycito Infotech Private Limited
+Copyright (c) 2017, Kalycito Infotech Private Limited
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
 All rights reserved.
 
@@ -145,7 +145,7 @@ static void       unmapMemory(tMemInfo* pMemInfo_p);
 #if defined(CONFIG_INCLUDE_VETH)
 static tOplkError getMemory(const void* pPCIeBuf_p,
                             void** ppKernelMem_p,
-                            UINT32 size_p);
+                            size_t size_p);
 static tOplkError nonPlkFrameSendCb(void* pBuffer_p,
                                     size_t size_p);
 static tOplkError receiveNonPlkFrame(void* pEvent_p);
@@ -658,7 +658,7 @@ with user application.
 \ingroup module_driver_ndispcie
 */
 //------------------------------------------------------------------------------
-tOplkError drv_getPdoMem(UINT32* pPdoMemOffs_p,
+tOplkError drv_getPdoMem(size_t* pPdoMemOffs_p,
                          size_t memSize_p)
 {
     tDualprocReturn dualRet;
@@ -684,7 +684,7 @@ tOplkError drv_getPdoMem(UINT32* pPdoMemOffs_p,
 
     offset = (UINT8*)pMem - pBar0;
 
-    *pPdoMemOffs_p = (UINT32)offset;
+    *pPdoMemOffs_p = (size_t)offset;
 
     DEBUG_LVL_ALWAYS_TRACE("%s() PDO memory offset is %x\n", __func__, offset);
     return kErrorOk;
@@ -783,7 +783,7 @@ the driver.
 //------------------------------------------------------------------------------
 tOplkError drv_mapKernelMem(void** ppKernelMem_p,
                             void** ppUserMem_p,
-                            UINT32* pSize_p)
+                            size_t* pSize_p)
 {
     tDualprocReturn         dualRet;
     tMemInfo*               pKernel2UserMemInfo = &drvInstance_l.kernel2UserMem;
@@ -1369,7 +1369,7 @@ the corresponding base address for the buffer in kernel virtual memory.
 //------------------------------------------------------------------------------
 static tOplkError getMemory(const void* pPCIeBuf_p,
                             void** ppKernelMem_p,
-                            UINT32 size_p)
+                            size_t size_p)
 {
     tMemInfo*   pKernel2UserMemInfo = &drvInstance_l.kernel2UserMem;
     ptrdiff_t   buffOffset;

--- a/drivers/windows/drv_ndis_pcie/drvintf.h
+++ b/drivers/windows/drv_ndis_pcie/drvintf.h
@@ -9,7 +9,7 @@ Driver interface for the kernel daemon - Header file
 *******************************************************************************/
 
 /*------------------------------------------------------------------------------
-Copyright (c) 2015, Kalycito Infotech Private Limited
+Copyright (c) 2017, Kalycito Infotech Private Limited
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
 All rights reserved.
 
@@ -85,13 +85,13 @@ tOplkError drv_readErrorObject(tErrHndIoctl* pReadObject_p);
 tOplkError drv_postEvent(const void* pEvent_p);
 tOplkError drv_getEvent(void* pEvent_p,
                         size_t* pSize_p);
-tOplkError drv_getPdoMem(UINT32* pPdoMemOffs_p,
+tOplkError drv_getPdoMem(size_t* pPdoMemOffs_p,
                          size_t memSize_p);
 tOplkError drv_getBenchmarkMem(void** ppBenchmarkMem_p);
 void       drv_freeBenchmarkMem(void* pBenchmarkMem_p);
 tOplkError drv_mapKernelMem(void** ppKernelMem_p,
                             void** ppUserMem_p,
-                            UINT32* pSize_p);
+                            size_t* pSize_p);
 void       drv_unmapKernelMem(void* pUserMem_p);
 tOplkError drv_writeFileBuffer(const tIoctlFileChunk* pIoctlFileChunk_p);
 size_t     drv_getFileBufferSize(void);

--- a/stack/include/common/driver.h
+++ b/stack/include/common/driver.h
@@ -92,8 +92,8 @@ kernel stack and mapped into user virtual address space.
 */
 typedef struct
 {
-    UINT32                  memSize;        ///< Size of PDO to be allocated and mapped
-    UINT32                  pdoMemOffset;   ///< Offset of PDO memory returned by kernel
+    size_t                  memSize;        ///< Size of PDO to be allocated and mapped
+    size_t                  pdoMemOffset;   ///< Offset of PDO memory returned by kernel
 } tPdoMem;
 
 /**
@@ -118,7 +118,7 @@ typedef struct
 {
     void*                   pKernelAddr;    ///< Pointer to the Kernel address
     void*                   pUserAddr;      ///< Pointer to the User address
-    UINT32                  size;           ///< Size of the shared memory
+    size_t                  size;           ///< Size of the shared memory
 } tMemStruc;
 
 //------------------------------------------------------------------------------

--- a/stack/src/user/pdo/pdoucalmem-winioctl.c
+++ b/stack/src/user/pdo/pdoucalmem-winioctl.c
@@ -163,7 +163,7 @@ tOplkError pdoucal_allocateMem(size_t memSize_p, UINT8** ppPdoMem_p)
     if (hFileHandle_l == NULL)
         return kErrorNoResource;
 
-    inPdoMem.memSize = (UINT)memSize_p;
+    inPdoMem.memSize = memSize_p;
 
     fIoctlRet = DeviceIoControl(hFileHandle_l,
                                 PLK_CMD_PDO_GET_MEM,


### PR DESCRIPTION
The data type definitions in the driver.h, drvintf.h and drvintf.c
of Windows designs are revised in order to comply with different
bit sizes of the target system (e.g. 64 bit).
