### PR TITLE
[FIX] Fix Xilinx and Altera documentation

### DIFF
--- a/doc/build-stack.md
+++ b/doc/build-stack.md
@@ -99,7 +99,7 @@ Follow the steps below to build the stack library on your host platform:
   Refer to \ref sect_build_stack_options_noos_microblaze for details!
 
 The default library installation path is:
-`<openPOWERLINK_dir>/stack/lib/generic/microblaze/<BOARD_NAME>/<DEMO_NAME>`
+`<openPOWERLINK_dir>/stack/lib/generic/microblazeise/<BOARD_NAME>/<DEMO_NAME>`
 
 ### Xilinx Microblaze (Vivado) {#sect_build_stack_build_microblaze}
 
@@ -268,7 +268,7 @@ the configuration options on the command line (-DCFG_XXX=XXX) or
 
 - **CFG_COMPILE_LIB_CNAPP_KERNELINTF**
 
-  Compile openPOWERLINK MN application library which contains the interface to
+  Compile openPOWERLINK CN application library which contains the interface to
   a Linux kernel space driver. It is used together with a Linux kernel module
   openPOWERLINK driver. It is configured to contain only CN functionality.
 

--- a/doc/supported-platforms/altera-cn.md
+++ b/doc/supported-platforms/altera-cn.md
@@ -407,7 +407,7 @@ The SOF file for the TERASIC_DE2-115 (INK) is located in the following subdirect
 
   or in debug mode use:
 
-  - `$ make download-elf && nios2-terminal -i <instance USB-Blaster (1 or 0)>`
+  - `$ make download-elf && nios2-terminal --instance=<0 or 1> --cable "USB-Blaster[USB-<0 or 1>]"`
 
 \note Workaround for testing without a Nios II license:\n
       If you did not specify a valid Nios II IP-Core license, the terminal windows

--- a/doc/supported-platforms/altera-mn.md
+++ b/doc/supported-platforms/altera-mn.md
@@ -126,6 +126,10 @@ Steps 1-5 can be carried out by executing `$ make all` in a
    For the two FPGA demos enter in both directories in the "Nios II Command
    Shell" \n
    `$ make download-elf` \n
+   or in debug mode use:
+
+   `$ make download-elf && nios2-terminal --instance=<0 or 1> --cable "USB-Blaster[USB-<0 or 1>]"`
+
 3. Enjoy the running POWERLINK network.
 
 # How to import the project into Nios II Software Build Tools for Eclipse for debugging purposes {#sect_altera-mn_import}

--- a/doc/supported-platforms/xilinx.md
+++ b/doc/supported-platforms/xilinx.md
@@ -126,7 +126,7 @@ the target the following steps need to be executed:
 * Open the `ISE Design Suite Command Prompt` and execute the following
   commands:\n
 
-      > cd <openPOWERLINK_directory>\bin\generic\microblaze\[BOARD_NAME]\[DEMO_NAME]
+      > cd <openPOWERLINK_directory>\bin\generic\microblazeise\[BOARD_NAME]\[DEMO_NAME]
       > make download-bits
       > make download-elf
 
@@ -172,7 +172,7 @@ completed and the binary is installed into the __bin__ directory.
 
       > cd <openPOWERLINK_dir>/contrib/bootloader/xilinx-microblaze/simpleboot/build
       > cmake -G"Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE=../../../../../cmake/toolchain-xilinx-ise-microblaze-gnu.cmake ../
-      > cmake -DCFG_BIN_DIR=../../../../../bin/generic/microblaze/avnet-s6plkeb/cn-single-gpio -DCFG_HW_LIB_DIR=../../../../../hardware/lib/generic/microblaze/avnet-s6plkeb/cn-single-gpio ../
+      > cmake -DCFG_BIN_DIR=../../../../../bin/generic/microblazeise/avnet-s6plkeb/cn-single-gpio -DCFG_HW_LIB_DIR=../../../../../hardware/lib/generic/microblaze/avnet-s6plkeb/cn-single-gpio ../
       > make all
       > make prog-flash
 

--- a/doc/supported-platforms/zynq-emacps.md
+++ b/doc/supported-platforms/zynq-emacps.md
@@ -93,7 +93,7 @@ to open the kernel configuration window:
 
 - Compile the kernel using the following command:
 
-      > make ARCH=arm CROSS_COMPILE=<Xilinx_dir>/SDK/2016.2/gnu/aarch32/lin/gcc-armlinux-gnueabi/bin/arm-linux-gnueabihf-
+      > make ARCH=arm CROSS_COMPILE=<Xilinx_dir>/SDK/2016.2/gnu/aarch32/lin/gcc-arm-linux-gnueabi/bin/arm-linux-gnueabihf-
 
 - To create uImage file:
 
@@ -102,11 +102,11 @@ to open the kernel configuration window:
 - Compile and install the modules for the Linux kernel using the following commands:
   * Compile modules:
 
-            > make ARCH=arm CROSS_COMPILE=<Xilinx_dir>/SDK/2016.2/gnu/aarch32/lin/gcc-armlinux-gnueabi/bin/arm-linux-gnueabihf- modules
+            > make ARCH=arm CROSS_COMPILE=<Xilinx_dir>/SDK/2016.2/gnu/aarch32/lin/gcc-arm-linux-gnueabi/bin/arm-linux-gnueabihf- modules
 
   * Install modules:
 
-            > make ARCH=arm CROSS_COMPILE=<Xilinx_dir>/SDK/2016.2/gnu/aarch32/lin/gcc-armlinux-gnueabi/bin/arm-linux-gnueabihf- modules_install
+            > make ARCH=arm CROSS_COMPILE=<Xilinx_dir>/SDK/2016.2/gnu/aarch32/lin/gcc-arm-linux-gnueabi/bin/arm-linux-gnueabihf- modules_install
 
 # Steps for cross-compiling the openPOWERLINK Linux MN for the Zynq Emacps design {#sect_cross_compile_openpowerlink}
 
@@ -192,7 +192,7 @@ generator and select **Specify toolchain file for cross-compiling** and click **
 - Provide the path for **Specify the Toolchain file** as below,
   - \<openPOWERLINK_dir\>/cmake/toolchain-xilinx-vivado-arm-linux-eabi-gnu.cmake
 - Click **Finish** to proceed.
-- Set CFG_KERNEL_DIR to the "<Xilinx_Linux_dir>" then select **CFG_POWERLINK_EDRV_EMACPS** and **CFG_OPLK_MN**.
+- Set CFG_BUILD_KERNEL_STACK to **Linux Kernel Module**.
 - Select **Configure** to apply the settings and click **Generate** to create the Makefile
 with the modified configuration.
 

--- a/doc/supported-platforms/zynq-hybrid.md
+++ b/doc/supported-platforms/zynq-hybrid.md
@@ -84,20 +84,20 @@ the Linux kernel source and create the kernel image file for the Zynq ZC702.
 
 - Compile the kernel using the following command:
 
-      > make ARCH=arm CROSS_COMPILE=<Xilinx_dir>/SDK/2016.2/gnu/aarch32/lin/gcc-armlinux-gnueabi/bin/arm-linux-gnueabihf-
+      > make ARCH=arm CROSS_COMPILE=<Xilinx_dir>/SDK/2016.2/gnu/aarch32/lin/gcc-arm-linux-gnueabi/bin/arm-linux-gnueabihf-
 
 - To create the uImage file:
 
-      > make ARCH=arm UIMAGE_LOADADDR=0x8000 uImage CROSS_COMPILE=<Xilinx_dir>/SDK/2016.2/gnu/aarch32/lin/gcc-armlinux-gnueabi/bin/arm-linux-gnueabihf-
+      > make ARCH=arm UIMAGE_LOADADDR=0x8000 uImage CROSS_COMPILE=<Xilinx_dir>/SDK/2016.2/gnu/aarch32/lin/gcc-arm-linux-gnueabi/bin/arm-linux-gnueabihf-
 
 - Compile and install the modules for the Linux kernel using the following commands:
   * Compile modules:
 
-            > make ARCH=arm CROSS_COMPILE=<Xilinx_dir>/SDK/2016.2/gnu/aarch32/lin/gcc-armlinux-gnueabi/bin/arm-linux-gnueabihf- modules
+            > make ARCH=arm CROSS_COMPILE=<Xilinx_dir>/SDK/2016.2/gnu/aarch32/lin/gcc-arm-linux-gnueabi/bin/arm-linux-gnueabihf- modules
 
   * Install modules:
 
-            > make ARCH=arm CROSS_COMPILE=<Xilinx_dir>/SDK/2016.2/gnu/aarch32/lin/gcc-armlinux-gnueabi/bin/arm-linux-gnueabihf- modules_install
+            > make ARCH=arm CROSS_COMPILE=<Xilinx_dir>/SDK/2016.2/gnu/aarch32/lin/gcc-arm-linux-gnueabi/bin/arm-linux-gnueabihf- modules_install
 
 # Steps to build the hardware for the Zynq Hybrid design {#sect_zynq_build_hardware}
 
@@ -127,7 +127,7 @@ the Linux kernel source and create the kernel image file for the Zynq ZC702.
 
 - Execute the following commands to build the hardware in **Release** mode:
 
-      > cmake ../.. -DCMAKE_BUILD_TYPE=Debug -DSKIP_BITSTREAM=OFF -DDEMO_Z702_MN_DUAL_SHMEM_GPIO=ON
+      > cmake ../.. -DCMAKE_BUILD_TYPE=Release -DSKIP_BITSTREAM=OFF -DDEMO_Z702_MN_DUAL_SHMEM_GPIO=ON
       > make install
 
 # Steps to build the PCP {#sect_zynq_build_pcp}
@@ -147,7 +147,7 @@ and build the PCP for the Zynq Hybrid design.
 
 - Execute the following commands to build the PCP in **Release** mode:
 
-      > cmake -GUnix\ Makefiles -DCMAKE_TOOLCHAIN_FILE=../../../cmake/toolchain-xilinx-microblaze-gnu.cmake ../.. -DCMAKE_BUILD_TYPE=Debug -DCFG_COMPILE_LIB_MNDRV_DUALPROCSHM=ON
+      > cmake -GUnix\ Makefiles -DCMAKE_TOOLCHAIN_FILE=../../../cmake/toolchain-xilinx-microblaze-gnu.cmake ../.. -DCMAKE_BUILD_TYPE=Release -DCFG_COMPILE_LIB_MNDRV_DUALPROCSHM=ON
       > make install
 
 ## Steps to build the driver application for Microblaze {#sect_build_driver_app_for_MB}
@@ -280,7 +280,7 @@ the Makefile with the modified configuration.
   - \<openPOWERLINK_dir\>/apps/demo_mn_console/
 - Provide the **Where to build the binaries** to the application build folder
   - \<openPOWERLINK_dir\>/apps/demo_mn_console/ build/linux
-- - Click the **Configure** button.
+- Click the **Configure** button.
 - In the **Specify the Generator for this project** dialog box, select **Unix Makefiles**
 generator and **Specify toolchain file for cross-compiling** and click **Next**.
 - Provide the path for **Specify the Toolchain file** as below
@@ -300,21 +300,25 @@ with the modified configuration.
 
 This section describes the steps to run the openPOWERLINK Linux MN demo on the Zynq ZC702 development board.
 
-- Refer to the link given below to convert the SD card to a bootable medium for the Zynq.
+- Refer to the link given below to convert the SD card to a bootable medium for the Zynq:
   * http://www.wiki.xilinx.com/Prepare+Boot+Medium
-- Refer to the link given below to download the Zynq ZC702 2016.2 pre-built Linux binaries.
+- Refer to the link given below to download the Zynq ZC702 2016.2 pre-built Linux binaries:
   * http://www.wiki.xilinx.com/Zynq+2016.2+Release
-- Extract and copy the following content from the downloaded folder to the boot partition of the SD card.
-  * uramdisk.image.gz
-  * devicetree.dtb
-  * BOOT.bin
-  * openPOWERLINK driver and application binaries from:
+- Extract the Zynq ZC702 2016.2 pre-built Linux binaries package.
+- Copy the following content to the boot partition of the SD card:
+  * uramdisk.image.gz from:
+    - Zynq ZC702 2016.2 pre-built Linux binaries package
+  * devicetree.dtb from:
+    - \<openPOWERLINK_dir>/hardware/boards/xilinx-z702/mn-dual-shmem-gpio/sdk/handoff
+  * BOOT.bin from:
+    - \<openPOWERLINK_dir>/tools/xilinx-zynqvivado
+  * openPOWERLINK driver and application folders from:
     - \<openPOWERLINK_dir\>/bin/linux/arm/oplkdrv_kernelmodule_zynq
     - \<openPOWERLINK_dir\>/bin/linux/arm/demo_mn_console
   * The uImage from:
     - \<Xilinx_Linux_dir\>/arch/arm/boot
 - Hardware setup
-  * Connect the Avnet expander board to the J3fmc1 connector of the Zynq ZC702 board.
+  * Connect the Avnet expander board to the J3 FMC1 connector of the Zynq ZC702 board.
   * Now connect the Ethernet cable to any of the Ethernet ports J6/J2 of the Avnet
 extension board and to a CN in the network.
 - To run openPOWERLINK


### PR DESCRIPTION
 - Update the command to download driver and application ELF in
   altera-cn.md and altera-mn.md
 - Add binary file path for Zynq Hybrid design
 - Update 'compiling application libraries' section in zynq-emacps.md
 - Update the default library installation paths for Xilinx
   Microblaze ISE design