### PR TITLE
[FIX] Fix type conversion warning in windows design

### DIFF
--- a/stack/src/user/sdo/sdoudp-windows.c
+++ b/stack/src/user/sdo/sdoudp-windows.c
@@ -275,7 +275,7 @@ tOplkError sdoudp_sendToSocket(const tSdoUdpCon* pSdoUdpCon_p,
 
     error = sendto(instance_l.udpSocket,
                    (const char*)&pSrcData_p->messageType,
-                   dataSize_p,
+                   (INT)dataSize_p,
                    0,
                    (struct sockaddr*)&addr,
                    sizeof(struct sockaddr_in));


### PR DESCRIPTION
 - Type cast size_t variable in sdoudp_windows module to
   suppress the compilation warning