### PR TITLE
[FIX] Update format specifier for size_t

### DIFF
--- a/apps/common/src/eventlog/eventlogstring.c
+++ b/apps/common/src/eventlog/eventlogstring.c
@@ -16,6 +16,7 @@ kEventlogFormatReadable is intended to be read by humans.
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2017, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -400,9 +401,9 @@ void eventlog_createCfmProgressEventString(const tCfmEventCnProgress* pProgress_
                             pProgress_p->objectSubIndex);
             len += snprintf(message_p + len,
                             messageSize_p - len,
-                            "SIZE:%05zu DOWNLOADED:%04zu ",
-                            pProgress_p->totalNumberOfBytes,
-                            pProgress_p->bytesDownloaded);
+                            "SIZE:%05lu DOWNLOADED:%04lu ",
+                            (ULONG)pProgress_p->totalNumberOfBytes,
+                            (ULONG)pProgress_p->bytesDownloaded);
             len += snprintf(message_p + len,
                             messageSize_p - len,
                             "ABORTCODE:0x%08X ERROR:0x%04X ",
@@ -420,9 +421,9 @@ void eventlog_createCfmProgressEventString(const tCfmEventCnProgress* pProgress_
 
             len += snprintf(message_p + len,
                             messageSize_p - len,
-                            "%4zu/%4zu Bytes",
-                            pProgress_p->bytesDownloaded,
-                            pProgress_p->totalNumberOfBytes);
+                            "%4lu/%4lu Bytes",
+                            (ULONG)pProgress_p->bytesDownloaded,
+                            (ULONG)pProgress_p->totalNumberOfBytes);
 
             if ((pProgress_p->sdoAbortCode != 0) ||
                 (pProgress_p->error != kErrorOk))

--- a/apps/common/src/firmwaremanager/firmwarecheck.c
+++ b/apps/common/src/firmwaremanager/firmwarecheck.c
@@ -11,6 +11,7 @@ This module implements firmware version checks of a found node.
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2017, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -967,8 +968,8 @@ static tFirmwareRet getIndexOfModuleFwDown(tFirmwareCheckNodeInfo* pNodeInfo_p,
 
     ret = issueSdoRead(pNodeInfo_p); if (ret != kFwReturnOk)
     {
-        FWM_ERROR("(%s) - reading the index of the %zu fw fownload object failed with %d\n",
-                  __func__, index_p, ret);
+        FWM_ERROR("(%s) - reading the index of the %lu fw fownload object failed with %d\n",
+                  __func__, (ULONG)index_p, ret);
     }
 
     return ret;
@@ -1022,9 +1023,9 @@ static tFirmwareRet processSdoEventForModule(tFirmwareCheckNodeInfo* pNodeInfo_p
 
     if (pSdoComFinished_p->transferredBytes != pNodeInfo_p->sdo.size)
     {
-        FWM_ERROR("Unexpected transferred bytes %zu instead of %zu for node %u index 0x%X subindex 0x%X\n",
-                  pSdoComFinished_p->transferredBytes,
-                  pNodeInfo_p->sdo.size,
+        FWM_ERROR("Unexpected transferred bytes %lu instead of %lu for node %u index 0x%X subindex 0x%X\n",
+                  (ULONG)pSdoComFinished_p->transferredBytes,
+                  (ULONG)pNodeInfo_p->sdo.size,
                   pNodeInfo_p->nodeId,
                   pNodeInfo_p->sdo.index,
                   pNodeInfo_p->sdo.subindex);
@@ -1227,16 +1228,16 @@ static tFirmwareRet processUpdateStateMachine(tFirmwareCheckNodeInfo* pNodeInfo_
                 {
                     if (isFirmwareUpdateRequired(pNodeInfo_p, &(*ppIter)->fwInfo))
                     {
-                        FWM_TRACE("Firmware update required for module %zu of node: %u\n",
-                                  modIdx, pNodeInfo_p->nodeId);
+                        FWM_TRACE("Firmware update required for module %lu of node: %u\n",
+                                  (ULONG)modIdx, pNodeInfo_p->nodeId);
                         pNodeInfo_p->nextUpdateState = kFwModuleUpdateStateGetNumberOfFwDownIndices;
                         (*ppIter)->moduleIndex = modIdx;
                         ppIter = &(*ppIter)->pNext;
                     }
                     else
                     {
-                        FWM_TRACE("No firmware update required for module %zu of node: %u\n",
-                                  modIdx, pNodeInfo_p->nodeId);
+                        FWM_TRACE("No firmware update required for module %lu of node: %u\n",
+                                  (ULONG)modIdx, pNodeInfo_p->nodeId);
                         pRem = *ppIter;
                         *ppIter = pRem->pNext;
                         pRem->pNext = NULL;

--- a/apps/common/src/firmwaremanager/firmwareupdate.c
+++ b/apps/common/src/firmwaremanager/firmwareupdate.c
@@ -11,6 +11,7 @@ This module implements firmware updates of a node with wrong version.
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2017, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -282,8 +283,8 @@ tFirmwareRet firmwareupdate_processSdoEvent(const tSdoComFinished* pSdoComFinish
 
     if (pSdoComFinished_p->transferredBytes != pInfo->firmwareSize)
     {
-        FWM_ERROR("SDO written number of bytes does not match for node 0x%X: %zu - %zu\n",
-                  pSdoComFinished_p->nodeId, pSdoComFinished_p->transferredBytes, pInfo->firmwareSize);
+        FWM_ERROR("SDO written number of bytes does not match for node 0x%X: %lu - %lu\n",
+                  pSdoComFinished_p->nodeId, (ULONG)pSdoComFinished_p->transferredBytes, (ULONG)pInfo->firmwareSize);
 
         fSucceeded = FALSE;
     }

--- a/apps/demo_mn_embedded/src/event.c
+++ b/apps/demo_mn_embedded/src/event.c
@@ -12,7 +12,7 @@ This file contains a demo MN application event handler.
 /*------------------------------------------------------------------------------
 Copyright (c) 2017, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
 Copyright (c) 2013, SYSTEC electronic GmbH
-Copyright (c) 2013, Kalycito Infotech Private Ltd.All rights reserved.
+Copyright (c) 2017, Kalycito Infotech Private Ltd.All rights reserved.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -435,7 +435,7 @@ static tOplkError processCfmProgressEvent(const tCfmEventCnProgress* pCfmProgres
            pCfmProgress_p->objectIndex,
            pCfmProgress_p->objectSubIndex);
 
-    PRINTF("%zu/%zu Bytes",
+    PRINTF("%lu/%lu Bytes",
            pCfmProgress_p->bytesDownloaded,
            pCfmProgress_p->totalNumberOfBytes);
 

--- a/stack/src/kernel/timesync/timesynckcal-hostif.c
+++ b/stack/src/kernel/timesync/timesynckcal-hostif.c
@@ -11,6 +11,7 @@ The sync module is responsible to synchronize the user layer.
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -277,7 +278,7 @@ static void* getSharedMemory(tHostifInstance pHifInstance_p)
 
     if (span < sizeof(tTimesyncSharedMemory))
     {
-        DEBUG_LVL_ERROR_TRACE("%s() Time Synchronization Buffer too small (shall be: %zu)\n",
+        DEBUG_LVL_ERROR_TRACE("%s() Time Synchronization Buffer too small (shall be: %lu)\n",
                               __func__,
                               sizeof(tTimesyncSharedMemory));
         return NULL;

--- a/stack/src/user/api/processimage.c
+++ b/stack/src/user/api/processimage.c
@@ -11,6 +11,7 @@ This source file contains the implementation of the process image functions.
 /*------------------------------------------------------------------------------
 Copyright (c) 2012, SYSTEC electronic GmbH
 Copyright (c) 2017, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2017, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -124,10 +125,10 @@ tOplkError oplk_allocProcessImage(size_t sizeProcessImageIn_p,
 {
     tOplkError  ret = kErrorOk;
 
-    DEBUG_LVL_ALWAYS_TRACE("%s(): Alloc(%zu, %zu)\n",
+    DEBUG_LVL_ALWAYS_TRACE("%s(): Alloc(%lu, %lu)\n",
                            __func__,
-                           sizeProcessImageIn_p,
-                           sizeProcessImageOut_p);
+                           (ULONG)sizeProcessImageIn_p,
+                           (ULONG)sizeProcessImageOut_p);
 
     if (!ctrlu_stackIsInitialized())
         return kErrorApiNotInitialized;
@@ -160,12 +161,12 @@ tOplkError oplk_allocProcessImage(size_t sizeProcessImageIn_p,
         OPLK_MEMSET(instance_l.outputImage.pImage, 0x00, sizeProcessImageOut_p);
     }
 
-    DEBUG_LVL_ALWAYS_TRACE("%s: Alloc(%p, %zu, %p, %zu)\n",
+    DEBUG_LVL_ALWAYS_TRACE("%s: Alloc(%p, %lu, %p, %lu)\n",
                            __func__,
                            instance_l.inputImage.pImage,
-                           instance_l.inputImage.imageSize,
+                           (ULONG)instance_l.inputImage.imageSize,
                            instance_l.outputImage.pImage,
-                           instance_l.outputImage.imageSize);
+                           (ULONG)instance_l.outputImage.imageSize);
 
     return ret;
 }

--- a/stack/src/user/timesync/timesyncucal-hostif.c
+++ b/stack/src/user/timesync/timesyncucal-hostif.c
@@ -269,7 +269,7 @@ static void* getSharedMemory(tHostifInstance pHifInstance_p)
 
     if (span < sizeof(tTimesyncSharedMemory))
     {
-        DEBUG_LVL_ERROR_TRACE("%s() Time Synchronization Buffer too small (shall be: %zu)\n",
+        DEBUG_LVL_ERROR_TRACE("%s() Time Synchronization Buffer too small (shall be: %lu)\n",
                               __func__,
                               sizeof(tTimesyncSharedMemory));
         return NULL;


### PR DESCRIPTION
 - The 'zu' format specifier is compatible from
   C99 compiler version.
 - In order to that, modify format specifier from
   'zu' to 'lu' to support different compilers.