### PR TITLE
Develop 2.7 fix kernel 4.14 build

### DIFF
--- a/drivers/linux/drv_kernelmod_edrv/main.c
+++ b/drivers/linux/drv_kernelmod_edrv/main.c
@@ -59,6 +59,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <linux/types.h>
 #include <linux/errno.h>
 #include <linux/version.h>
+#include <linux/uaccess.h>
 #include <linux/mm.h>
 #include <asm/uaccess.h>
 #include <asm/page.h>

--- a/stack/src/kernel/edrv/edrv-i210.c
+++ b/stack/src/kernel/edrv/edrv-i210.c
@@ -2754,7 +2754,11 @@ static int initOnePciDev(struct pci_dev* pPciDev_p, const struct pci_device_id* 
             edrvInstance_l.pMsixEntry[index].entry = index;
         }
 
+#if (LINUX_VERSION_CODE>=KERNEL_VERSION(4,12,0))
+        result = pci_enable_msix_exact(pPciDev_p, edrvInstance_l.pMsixEntry, numVectors);
+#else
         result = pci_enable_msix(pPciDev_p, edrvInstance_l.pMsixEntry, numVectors);
+#endif
         if (result != 0)
         {
             printk("...Failed\n");

--- a/stack/src/kernel/event/eventkcal-linuxkernel.c
+++ b/stack/src/kernel/event/eventkcal-linuxkernel.c
@@ -54,6 +54,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <linux/delay.h>
 #include <linux/sched.h>
 #include <linux/cpumask.h>
+#include <linux/uaccess.h>
 #include <asm/uaccess.h>
 #include <asm/atomic.h>
 

--- a/stack/src/kernel/veth/veth-linuxkernel.c
+++ b/stack/src/kernel/veth/veth-linuxkernel.c
@@ -169,7 +169,12 @@ tOplkError veth_init(const UINT8 aSrcMac_p[6])
 
     pVEthNetDevice_g->netdev_ops = &oplk_netdev_ops;
     pVEthNetDevice_g->watchdog_timeo = VETH_TX_TIMEOUT;
+#if (LINUX_VERSION_CODE>=KERNEL_VERSION(4,11,9))
+    pVEthNetDevice_g->needs_free_netdev = false;
+    pVEthNetDevice_g->priv_destructor = free_netdev;
+#else
     pVEthNetDevice_g->destructor = free_netdev;
+#endif
 
     // copy own MAC address to net device structure
     OPLK_MEMCPY(pVEthNetDevice_g->dev_addr, aSrcMac_p, 6);


### PR DESCRIPTION
There are some API changes in the latest kernels.
I noticed them while bumping the openpowerlink package in Buildroot and build testing against a 4.14 kernel.
No real runtime testing...