### PR TITLE
[FIX] Modify driver and installer binary generation path in NDIS

### DIFF
--- a/drivers/windows/drv_ndis_intermediate/build/drv_ndis_intermediate_package/drv_ndis_intermediate_package.vcxproj
+++ b/drivers/windows/drv_ndis_intermediate/build/drv_ndis_intermediate_package/drv_ndis_intermediate_package.vcxproj
@@ -100,7 +100,7 @@
     <VerifyProjectOutput>True</VerifyProjectOutput>
     <VerifyDrivers />
     <VerifyFlags>133563</VerifyFlags>
-    <OutDir>$(SolutionDir)..\..\..\..\bin\windows\$(PROCESSOR_ARCHITEW6432)\</OutDir>
+    <OutDir>$(SolutionDir)..\..\..\..\bin\windows\amd64\$(PROCESSOR_ARCHITEW6432)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win7 Release|x64'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
@@ -114,7 +114,7 @@
     <VerifyProjectOutput>True</VerifyProjectOutput>
     <VerifyDrivers />
     <VerifyFlags>133563</VerifyFlags>
-    <OutDir>$(SolutionDir)..\..\..\..\bin\windows\$(PROCESSOR_ARCHITEW6432)\</OutDir>
+    <OutDir>$(SolutionDir)..\..\..\..\bin\windows\amd64\$(PROCESSOR_ARCHITEW6432)\</OutDir>
   </PropertyGroup>
   <ItemGroup>
     <FilesToPackage Include="@(Inf->'%(CopyOutput)')" Condition="'@(Inf)'!=''" />

--- a/tools/windows/installer-ndisim/build/installer-ndisim.vcxproj
+++ b/tools/windows/installer-ndisim/build/installer-ndisim.vcxproj
@@ -93,8 +93,8 @@
       <AdditionalDependencies>setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;Cfgmgr32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>mkdir $(SolutionDir)..\..\..\..\bin\windows\$(PlatformName)\$(SolutionName)\
-copy  $(OutputPath)$(TargetFileName) $(SolutionDir)..\..\..\..\bin\windows\$(PlatformName)\$(SolutionName)\</Command>
+      <Command>mkdir $(SolutionDir)..\..\..\..\bin\windows\amd64\$(PlatformName)\$(SolutionName)\
+copy  $(OutputPath)$(TargetFileName) $(SolutionDir)..\..\..\..\bin\windows\amd64\$(PlatformName)\$(SolutionName)\</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -112,8 +112,8 @@ copy  $(OutputPath)$(TargetFileName) $(SolutionDir)..\..\..\..\bin\windows\$(Pla
       <AdditionalDependencies>setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;Cfgmgr32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>mkdir $(SolutionDir)..\..\..\..\bin\windows\$(PROCESSOR_ARCHITEW6432)\$(SolutionName)\
-copy  $(OutputPath)$(TargetFileName) $(SolutionDir)..\..\..\..\bin\windows\$(PROCESSOR_ARCHITEW6432)\$(SolutionName)\</Command>
+      <Command>mkdir $(SolutionDir)..\..\..\..\bin\windows\amd64\$(PROCESSOR_ARCHITEW6432)\$(SolutionName)\
+copy  $(OutputPath)$(TargetFileName) $(SolutionDir)..\..\..\..\bin\windows\amd64\$(PROCESSOR_ARCHITEW6432)\$(SolutionName)\</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -135,8 +135,8 @@ copy  $(OutputPath)$(TargetFileName) $(SolutionDir)..\..\..\..\bin\windows\$(PRO
       <AdditionalDependencies>setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>mkdir $(SolutionDir)..\..\..\..\bin\windows\$(PlatformName)\$(SolutionName)\
-copy  $(OutputPath)$(TargetFileName) $(SolutionDir)..\..\..\..\bin\windows\$(PlatformName)\$(SolutionName)\</Command>
+      <Command>mkdir $(SolutionDir)..\..\..\..\bin\windows\amd64\$(PlatformName)\$(SolutionName)\
+copy  $(OutputPath)$(TargetFileName) $(SolutionDir)..\..\..\..\bin\windows\amd64\$(PlatformName)\$(SolutionName)\</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -158,8 +158,8 @@ copy  $(OutputPath)$(TargetFileName) $(SolutionDir)..\..\..\..\bin\windows\$(Pla
       <AdditionalDependencies>setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;Cfgmgr32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>mkdir $(SolutionDir)..\..\..\..\bin\windows\$(PROCESSOR_ARCHITEW6432)\$(SolutionName)\
-copy  $(OutputPath)$(TargetFileName) $(SolutionDir)..\..\..\..\bin\windows\$(PROCESSOR_ARCHITEW6432)\$(SolutionName)\</Command>
+      <Command>mkdir $(SolutionDir)..\..\..\..\bin\windows\amd64\$(PROCESSOR_ARCHITEW6432)\$(SolutionName)\
+copy  $(OutputPath)$(TargetFileName) $(SolutionDir)..\..\..\..\bin\windows\amd64\$(PROCESSOR_ARCHITEW6432)\$(SolutionName)\</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
Update the driver and installer binary generation path from
 "bin\windows" to "bin\windows\amd64" in Windows NDIS design

This fix is for issue #318
