### PR TITLE
[FIX] Update Veth files to forward non-powerlink frames to user layer

### DIFF
--- a/stack/src/kernel/veth/veth-linuxkernel.c
+++ b/stack/src/kernel/veth/veth-linuxkernel.c
@@ -13,6 +13,7 @@ implementation.
 /*------------------------------------------------------------------------------
 Copyright (c) 2013, SYSTEC electronic GmbH
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2018, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -402,6 +403,14 @@ static tOplkError receiveFrameCb(tFrameInfo* pFrameInfo_p,
                          pFrameInfo_p->frame.pBuffer->aSrcMac[3],
                          pFrameInfo_p->frame.pBuffer->aSrcMac[4],
                          pFrameInfo_p->frame.pBuffer->aSrcMac[5]);
+
+    // Forward the non-powerlink frame via async receive FIFO to userspace
+    ret = dllkcal_asyncFrameReceived(pFrameInfo_p);
+    if (ret == kErrorReject)
+    {
+        *pReleaseRxBuffer_p = kEdrvReleaseRxBufferLater;
+        ret = kErrorOk;
+    }
 
     // update receive statistics
     pStats->rx_packets++;

--- a/stack/src/kernel/veth/veth-linuxuser.c
+++ b/stack/src/kernel/veth/veth-linuxuser.c
@@ -12,6 +12,7 @@ implementation. It uses a TUN/TAP device as virtual Ethernet driver.
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+Copyright (c) 2018, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -368,6 +369,14 @@ static void* vethRecvThread(void* pArg_p)
                     if (ret != kErrorOk)
                     {
                         DEBUG_LVL_VETH_TRACE("%s(): dllkcal_sendAsyncFrame returned 0x%04X\n", __func__, ret);
+                    }
+
+                    // Forward the non-powerlink frame via async receive FIFO to userspace
+                    ret = dllkcal_asyncFrameReceived(&frameInfo);
+                    if (ret != kErrorOk)
+                    {
+                        DEBUG_LVL_VETH_TRACE("%s(): dllkcal_asyncFrameReceived returned 0x%04X\n",
+                                             __func__, ret);
                     }
                 }
                 break;


### PR DESCRIPTION
Update Linux userspace, Linux Kernel edrv and Windows NDIS
'Veth' files to forward the received non-powerlink frames
to user layer via async receive FIFO.

This fix resolves #319. (Tested designs: Linux edrv, pcap, PCIe and Windows NDIS)

Limitation:
This fix is not applicable for Windows PCIe and Zynq hybrid, as the fix is yet to be implemented for the mentioned designs.