### PR TITLE
[FIX] Update user layer Veth name for Zynq emacps design

### DIFF
--- a/stack/proj/linux/liboplkmnapp-kernelintf/CMakeLists.txt
+++ b/stack/proj/linux/liboplkmnapp-kernelintf/CMakeLists.txt
@@ -3,6 +3,7 @@
 # CMake file of openPOWERLINK application MN library with kernelspace interface
 #
 # Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
+# Copyright (c) 2018, Kalycito Infotech Private Limited
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -61,6 +62,7 @@ IF(CMAKE_SYSTEM_PROCESSOR MATCHES "^(i.86|x86(_64)?)$")
     SET(LIB_SOURCES ${LIB_SOURCES} ${ARCH_X86_SOURCES})
 ELSEIF(CMAKE_SYSTEM_PROCESSOR MATCHES arm*)
     SET(LIB_SOURCES ${LIB_SOURCES} ${ARCH_LE_SOURCES})
+    ADD_DEFINITIONS(-DCONFIG_EMACPS_VETH_NAME)
 ELSE()
     MESSAGE(FATAL_ERROR "Unsupported CMAKE_SYSTEM_PROCESSOR ${CMAKE_SYSTEM_PROCESSOR}")
 ENDIF()

--- a/stack/proj/linux/liboplkmnapp-kernelintf/oplkcfg.h
+++ b/stack/proj/linux/liboplkmnapp-kernelintf/oplkcfg.h
@@ -12,7 +12,7 @@ application libary on Linux which is using the kernelspace interface.
 /*------------------------------------------------------------------------------
 Copyright (c) 2012, SYSTEC electronik GmbH
 Copyright (c) 2017, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
-Copyright (c) 2017, Kalycito Infotech Private Limited.
+Copyright (c) 2018, Kalycito Infotech Private Limited.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -80,6 +80,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONFIG_VETH_SET_DEFAULT_GATEWAY                 FALSE
 
 #define CONFIG_CHECK_HEARTBEAT_PERIOD                   100        // 100 ms
+
+// Update PLK_VETH_NAME to avoid Veth name mismatch between kernel and
+// user layer of Zynq Emacps design
+#if defined(CONFIG_EMACPS_VETH_NAME)
+#define PLK_VETH_NAME                                   "plk_veth" // name of net device in Linux
+#endif
 
 //==============================================================================
 // Data Link Layer (DLL) specific defines


### PR DESCRIPTION
Update user layer Veth name to 'plk_veth' in order to match
with the kernel Veth name of Zynq emacps design. This fix resolves
the name conflict of PLK_VETH_NAME between kernel and user.

This fix resolves #317 for Zynq EmacPS design.