### PR TITLE
[FIX] Fix Compilation issue in Windows NDIS 32 bit

### DIFF
--- a/doc/build-drivers.md
+++ b/doc/build-drivers.md
@@ -90,17 +90,29 @@ Windows Driver Kit (WDK) 8.1 for compilation.
 Follow the steps below to build the NDIS driver on a Windows system using MSbuild.
 Open a Visual Studio command line and enter the following commands:
 
-* Build driver for Windows 7 (64 bit) in debug mode
+* Build driver for Windows 7 & 10 (64 bit) in debug mode
 
       > cd <openPOWERLINK_dir>\drivers\windows\drv_ndis_[pcie;intermediate]\build
       > cmake -G"NMake Makefiles" -DCMAKE_BUILD_TYPE=Debug ..
       > msbuild /t:build /p:Platform=x64 /p:Configuration="Win7 Debug"
 
-* Build driver for Windows 7 (64 bit) in release mode
+* Build driver for Windows 7 & 10 (64 bit) in release mode
 
       > cd <openPOWERLINK_dir>\drivers\windows\drv_ndis_[pcie;intermediate]\build
       > cmake -G"NMake Makefiles" -DCMAKE_BUILD_TYPE=Release ..
       > msbuild /t:build /p:Platform=x64 /p:Configuration="Win7 Release"
+
+* Build driver for Windows 7 & 10 (32 bit) in debug mode
+
+      > cd <openPOWERLINK_dir>\drivers\windows\drv_ndis_[pcie;intermediate]\build
+      > cmake -G"NMake Makefiles" -DCMAKE_BUILD_TYPE=Debug ..
+      > msbuild /t:build /p:Platform=Win32 /p:Configuration="Win7 Debug"
+
+* Build driver for Windows 7 & 10 (32 bit) in release mode
+
+      > cd <openPOWERLINK_dir>\drivers\windows\drv_ndis_[pcie;intermediate]\build
+      > cmake -G"NMake Makefiles" -DCMAKE_BUILD_TYPE=Release ..
+      > msbuild /t:build /p:Platform=Win32 /p:Configuration="Win7 Release"
 
 `Platform` and `Configuration` parameters can be modified to compile the driver for
 a different platform and Windows version.

--- a/doc/supported-platforms/windows.md
+++ b/doc/supported-platforms/windows.md
@@ -211,7 +211,14 @@ Follow the steps below to build the NDIS intermediate driver installer.
   - Build installer application
 
         > cd <openPOWERLINK_directory>\tools\windows\installer-ndisim\build
-        > msbuild /t:build /p:Platform=x64 /p:Configuration="Release"
+
+        - Build in 64-bit Environment
+
+             > msbuild /t:build /p:Platform=x64 /p:Configuration="Release"
+
+        - Build in 32-bit Environment
+
+             > msbuild /t:build /p:Platform=Win32 /p:Configuration="Release"
 
 * Copy the required Visual C++ Redistributable executable to `tools/windows/installer`
 directory.
@@ -224,13 +231,21 @@ directory.
 
 * Compile the NSIS script to generate the openPOWERLINK driver installer executable.
 
+  Use oplk-ndisim-x64.nsi script for 64-bit Windows and oplk-ndisim-x86.nsi for 32-bit
+  Windows driver installation
+
   The script can be compiled either from the context menu option `Compile NSIS Script` or
   using the command line utility `makensis`.
+  Command line utility for 32-bit Windows is given below.
 
-      > makensis <openPOWERLINK_directory>\tools\windows\installer\oplk-ndisim.nsi
+      > makensis <openPOWERLINK_directory>\tools\windows\installer\oplk-ndisim-x86.nsi
+
+  Command line utility for 64-bit Windows is given below.
+
+      > makensis <openPOWERLINK_directory>\tools\windows\installer\oplk-ndisim-x64.nsi
 
 The default installation location for the openPOWERLINK driver installer executable is:
-`bin\windows\amd64`
+`bin\windows\amd64` for 64-bit and `bin\windows\x86` for 32-bit
 
 __NOTE:__ Currently the script supports creation of executable only for 64-bit Windows.
 

--- a/drivers/windows/drv_ndis_intermediate/build/drv_ndis_intermediate/drv_ndis_intermediate.vcxproj
+++ b/drivers/windows/drv_ndis_intermediate/build/drv_ndis_intermediate/drv_ndis_intermediate.vcxproj
@@ -60,10 +60,16 @@
   <PropertyGroup />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win7 Debug|Win32'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
+    <OutDir>..\$(Platform)\$(ConfigurationName)\</OutDir>
+    <IntDir>$(TargetName).dir\Debug\</IntDir>
+    <TargetName>$(TargetName.Replace(' ',''))</TargetName>
     <EnableInf2cat>false</EnableInf2cat>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win7 Release|Win32'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
+    <OutDir>..\$(Platform)\$(ConfigurationName)\</OutDir>
+    <IntDir>$(TargetName).dir\Debug\</IntDir>
+    <TargetName>$(TargetName.Replace(' ',''))</TargetName>
     <EnableInf2cat>false</EnableInf2cat>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win7 Debug|x64'">
@@ -93,7 +99,13 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);$(KernelBufferOverflowLib);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\hal.lib;$(DDK_LIB_PATH)\wmilib.lib;$(DDK_LIB_PATH)\ndis.lib</AdditionalDependencies>
+      <GenerateMapFile>true</GenerateMapFile>
+      <MapExports>true</MapExports>
+      <AssemblyDebug>true</AssemblyDebug>
     </Link>
+    <Inf>
+      <TimeStamp>2.2.0.0</TimeStamp>
+    </Inf>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Win7 Release|Win32'">
     <ClCompile>
@@ -110,7 +122,13 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);$(KernelBufferOverflowLib);$(DDK_LIB_PATH)\ntoskrnl.lib;$(DDK_LIB_PATH)\hal.lib;$(DDK_LIB_PATH)\wmilib.lib;$(DDK_LIB_PATH)\ndis.lib</AdditionalDependencies>
+      <GenerateMapFile>true</GenerateMapFile>
+      <MapExports>true</MapExports>
+      <AssemblyDebug>true</AssemblyDebug>
     </Link>
+    <Inf>
+      <TimeStamp>2.2.0.0</TimeStamp>
+    </Inf>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Win7 Debug|x64'">
     <ClCompile>

--- a/drivers/windows/drv_ndis_intermediate/build/drv_ndis_intermediate_package/drv_ndis_intermediate_package.vcxproj
+++ b/drivers/windows/drv_ndis_intermediate/build/drv_ndis_intermediate_package/drv_ndis_intermediate_package.vcxproj
@@ -74,6 +74,8 @@
     <VerifyProjectOutput>True</VerifyProjectOutput>
     <VerifyDrivers />
     <VerifyFlags>133563</VerifyFlags>
+    <OutDir>$(SolutionDir)..\..\..\..\bin\windows\$(PROCESSOR_ARCHITECTURE)\</OutDir>
+    <IntDir>$(Platform)\$(ConfigurationName)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win7 Release|Win32'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
@@ -87,6 +89,8 @@
     <VerifyProjectOutput>True</VerifyProjectOutput>
     <VerifyDrivers />
     <VerifyFlags>133563</VerifyFlags>
+    <OutDir>$(SolutionDir)..\..\..\..\bin\windows\$(PROCESSOR_ARCHITECTURE)\</OutDir>
+    <IntDir>$(Platform)\$(ConfigurationName)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win7 Debug|x64'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
@@ -120,9 +124,6 @@
     <FilesToPackage Include="@(Inf->'%(CopyOutput)')" Condition="'@(Inf)'!=''" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\drv_ndis_intermediate\drv_ndis_intermediate.vcxproj">
-      <Project>{be53555d-b97e-480a-9cab-29aa58d34d00}</Project>
-    </ProjectReference>
     <ProjectReference Include="..\notifyObj\notifyObj.vcxproj">
       <Project>{293ba7ca-111d-4125-864a-ad5edd9de5cc}</Project>
     </ProjectReference>

--- a/drivers/windows/drv_ndis_intermediate/build/notifyObj/notifyObj.vcxproj
+++ b/drivers/windows/drv_ndis_intermediate/build/notifyObj/notifyObj.vcxproj
@@ -66,6 +66,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win7 Debug|Win32'">
     <IgnoreImportLibrary>true</IgnoreImportLibrary>
     <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)$(Platform)\$(ConfigurationName)\</OutDir>
+    <IntDir>$(Platform)\$(ConfigurationName)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win7 Debug|x64'">
     <IgnoreImportLibrary>true</IgnoreImportLibrary>
@@ -74,10 +76,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win7 Release|Win32'">
     <IgnoreImportLibrary>true</IgnoreImportLibrary>
     <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)$(Platform)\$(ConfigurationName)\</OutDir>
+    <IntDir>$(Platform)\$(ConfigurationName)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win7 Release|x64'">
     <IgnoreImportLibrary>true</IgnoreImportLibrary>
     <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)$(Platform)\$(ConfigurationName)\</OutDir>
+    <IntDir>$(Platform)\$(ConfigurationName)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Win7 Debug|Win32'">
     <ClCompile>
@@ -91,7 +97,6 @@
     </ClCompile>
     <Midl>
       <MkTypLibCompatible>false</MkTypLibCompatible>
-      <TargetEnvironment>Win32</TargetEnvironment>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <HeaderFileName>notifyObj_i.h</HeaderFileName>
       <InterfaceIdentifierFileName>notifyObj_i.c</InterfaceIdentifierFileName>
@@ -99,6 +104,7 @@
       <GenerateStublessProxies>true</GenerateStublessProxies>
       <TypeLibraryName>$(IntDir)notifyObj.tlb</TypeLibraryName>
       <DllDataFileName />
+      <OutputDirectory>$(IntDir)</OutputDirectory>
       <ValidateAllParameters>true</ValidateAllParameters>
     </Midl>
     <ResourceCompile>

--- a/tools/windows/installer-ndisim/build/installer-ndisim.vcxproj
+++ b/tools/windows/installer-ndisim/build/installer-ndisim.vcxproj
@@ -93,8 +93,8 @@
       <AdditionalDependencies>setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;Cfgmgr32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>mkdir $(SolutionDir)..\..\..\..\bin\windows\$(PlatformName)\$(SolutionName)\
-copy  $(OutputPath)$(TargetFileName) $(SolutionDir)..\..\..\..\bin\windows\$(PlatformName)\$(SolutionName)\</Command>
+      <Command>mkdir $(SolutionDir)..\..\..\..\bin\windows\x86\$(SolutionName)\
+copy  $(OutputPath)$(TargetFileName) $(SolutionDir)..\..\..\..\bin\windows\x86\$(SolutionName)\</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -135,8 +135,8 @@ copy  $(OutputPath)$(TargetFileName) $(SolutionDir)..\..\..\..\bin\windows\$(PRO
       <AdditionalDependencies>setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>mkdir $(SolutionDir)..\..\..\..\bin\windows\$(PlatformName)\$(SolutionName)\
-copy  $(OutputPath)$(TargetFileName) $(SolutionDir)..\..\..\..\bin\windows\$(PlatformName)\$(SolutionName)\</Command>
+      <Command>mkdir $(SolutionDir)..\..\..\..\bin\windows\x86\$(SolutionName)\
+copy  $(OutputPath)$(TargetFileName) $(SolutionDir)..\..\..\..\bin\windows\x86\$(SolutionName)\</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/tools/windows/installer/oplk-ndisim-x64.nsi
+++ b/tools/windows/installer/oplk-ndisim-x64.nsi
@@ -1,5 +1,5 @@
 ;------------------------------------------------------------------------------
-; \file oplk-ndisim.nsi
+; \file oplk-ndisim-x64.nsi
 ;
 ; \brief NSIS Installer script for NDIS intermediate driver
 ;
@@ -9,7 +9,7 @@
 ;------------------------------------------------------------------------------
 
 ;------------------------------------------------------------------------------
-;Copyright(c) 2015, Kalycito Infotech Private Limited
+;Copyright(c) 2018, Kalycito Infotech Private Limited
 ;All rights reserved.
 
 ;Redistribution and use in source and binary forms, with or without

--- a/tools/windows/installer/oplk-ndisim-x86.nsi
+++ b/tools/windows/installer/oplk-ndisim-x86.nsi
@@ -1,0 +1,137 @@
+;------------------------------------------------------------------------------
+; \file oplk-ndisim-x86.nsi
+;
+; \brief NSIS Installer script for NDIS intermediate driver
+;
+; This file contains the NSIS script to create a Windows installer for the NDIS
+; intermediate driver. The installer will allow users to install the driver
+; using single click.
+;------------------------------------------------------------------------------
+
+;------------------------------------------------------------------------------
+;Copyright(c) 2018, Kalycito Infotech Private Limited
+;All rights reserved.
+
+;Redistribution and use in source and binary forms, with or without
+;modification, are permitted provided that the following conditions are met :
+;    * Redistributions of source code must retain the above copyright
+;      notice, this list of conditions and the following disclaimer.
+;    * Redistributions in binary form must reproduce the above copyright
+;      notice, this list of conditions and the following disclaimer in the
+;      documentation and / or other materials provided with the distribution.
+;    * Neither the name of the copyright holders nor the
+;      names of its contributors may be used to endorse or promote products
+;      derived from this software without specific prior written permission.
+;
+;THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+;ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+;WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+;DISCLAIMED.IN NO EVENT SHALL COPYRIGHT HOLDERS BE LIABLE FOR ANY
+;DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+;(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+;LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+;ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+;(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+;SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+;Include Modern UI
+
+  !include "MUI2.nsh"
+  !include "LogicLib.nsh"
+  !include "x64.nsh"
+
+;--------------------------------
+;Variables
+
+  Var StartMenuFolder
+
+  ;--------------------------------
+;General
+
+  ;Name and file
+   Name    "openPOWERLINK NDIS IM driver"
+   OutFile "..\..\..\bin\windows\x86\oplk_ndisim.exe"
+   VIProductVersion 1.0.0.0
+   VIAddVersionKey ProductName "openPOWERLINK NDIS IM driver v2.3.0.0"
+   VIAddVersionKey CompanyName "Ethernet POWERLINK Standardization Group (EPSG)"
+   VIAddVersionKey ProductVersion 2.3.0.0
+   VIAddVersionKey FileDescription "openPOWERLINK NDIS IM driver installer"
+
+  ;Default installation folder
+   InstallDir "$PROGRAMFILES\openPOWERLINK NDIS IM Driver"
+
+  ;Get installation folder from registry if available
+   InstallDirRegKey HKCU "Software\oplk_ndisim" ""
+
+  ;Request application privileges for Windows 7 & WinXP
+   RequestExecutionLevel admin
+
+   ;Interface Settings
+
+  !define MUI_ABORTWARNING
+
+  ;--------------------------------
+;Pages
+;page Components InitComponentsPage
+
+
+  !insertmacro MUI_PAGE_COMPONENTS
+  !insertmacro MUI_PAGE_DIRECTORY
+
+  !insertmacro MUI_PAGE_STARTMENU Application $StartMenuFolder
+
+  !insertmacro MUI_PAGE_INSTFILES
+
+
+  !insertmacro MUI_UNPAGE_CONFIRM
+  !insertmacro MUI_UNPAGE_COMPONENTS
+  !insertmacro MUI_UNPAGE_INSTFILES
+
+;Start Menu Folder Page Configuration
+  !define MUI_STARTMENUPAGE_REGISTRY_ROOT "HKCU"
+  !define MUI_STARTMENUPAGE_REGISTRY_KEY "Software\openPOWERLINK NDIS IM Driver"
+  !define MUI_STARTMENUPAGE_REGISTRY_VALUENAME "Start Menu Folder"
+
+ !define DIR
+;Languages
+
+  !insertmacro MUI_LANGUAGE "English"
+
+
+;Installer Sections
+
+Section "NDIS IM Driver" section1
+;Create directories in program files.
+    WriteRegStr HKCU "Software\openPOWERLINK NDIS IM Driver" "" "$INSTDIR"
+    SetOutPath "$INSTDIR\Driver"
+    File  /r "..\..\..\bin\windows\x86\drv_ndis_intermediate_package\*.*"
+    File  /r "..\..\..\bin\windows\x86\installer-ndisim\*.*"
+    SetOutPath "$INSTDIR\Temp"
+    File /r "vcredist_x86.exe"
+
+    ExecWait "$INSTDIR\Temp\vcredist_x86.exe /passive /norestart"
+    SetOutPath "$INSTDIR\Driver"
+    ExecWait "$INSTDIR\Driver\installer-ndisim.exe /Install"
+    WriteUninstaller $INSTDIR\uninstaller.exe
+    !insertmacro MUI_STARTMENU_WRITE_BEGIN Application
+    CreateDirectory "$SMPROGRAMS\$StartMenuFolder"
+    CreateShortCut "$SMPROGRAMS\$StartMenuFolder\uninstaller.lnk" "$INSTDIR\uninstaller.exe"
+    !insertmacro MUI_STARTMENU_WRITE_END
+
+SectionEnd
+
+Section "Uninstall"
+SetOutPath "$INSTDIR\Driver"
+ExecWait "$INSTDIR\Driver\installer-ndisim.exe /Uninstall"
+  ; Remove registry keys
+   DeleteRegKey HKLM "SOFTWARE\openPOWERLINK NDIS IM Driver"
+  ; Remove files and uninstaller
+   Delete $INSTDIR\uninstall.exe
+   Delete "$INSTDIR\*.*"
+   RMDir /r "$INSTDIR\*.*"
+   RMDir /r "$PROGRAMFILES\openPOWERLINK NDIS IM Driver\*.*"
+  ; Remove shortcuts, if any
+   Delete "$SMPROGRAMS\$StartMenuFolder\uninstaller.lnk"
+   RMDir /r "$SMPROGRAMS\$StartMenuFolder\"
+SectionEnd


### PR DESCRIPTION
Update the driver and installer binary generation path for both 32bit and 64bit from
"bin\windows" to "bin\windows<amd64/x86>" in Windows NDIS design.

Paths in doxygen documentation is also updated.
This fix resolves #318

Change-Id: I08ca898741483863a960d01154594e3ab9e72d8e

This pull request implements the comments for the previous request #331