### PR TITLE
[TASK] Update net device name as plk_veth for all platforms

### DIFF
--- a/drivers/linux/drv_kernelmod_edrv/proj/mn/oplkcfg.h
+++ b/drivers/linux/drv_kernelmod_edrv/proj/mn/oplkcfg.h
@@ -11,7 +11,7 @@ This file contains the configuration options for the openPOWERLINK kernel module
 /*------------------------------------------------------------------------------
 Copyright (c) 2012, SYSTEC electronik GmbH
 Copyright (c) 2014, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
-Copyright (c) 2017, Kalycito Infotech Private Limited.
+Copyright (c) 2018, Kalycito Infotech Private Limited.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -65,12 +65,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONFIG_INCLUDE_SOC_TIME_FORWARD
 
 #define CONFIG_DLLCAL_QUEUE                         CIRCBUF_QUEUE
-
-// Update device name to avoid conflict in zynq emacps design
-// 267200 corresponds to Z7200 architecture of Zynq family. (Z is represented by 26)
-#if (CONFIG_EDRV == 267200)
-#define PLK_VETH_NAME                               "plk_veth"
-#endif
 
 //==============================================================================
 // Ethernet driver (Edrv) specific defines

--- a/drivers/linux/drv_kernelmod_zynq/proj/mn/oplkcfg.h
+++ b/drivers/linux/drv_kernelmod_zynq/proj/mn/oplkcfg.h
@@ -13,7 +13,7 @@ as the equivalent configurations in user and kernel layers of the stack.
 /*------------------------------------------------------------------------------
 Copyright (c) 2012, SYSTEC electronik GmbH
 Copyright (c) 2014, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
-Copyright (c) 2017, Kalycito Infotech Private Limited
+Copyright (c) 2018, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -66,10 +66,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONFIG_INCLUDE_SOC_TIME_FORWARD
 
 #define CONFIG_DLLCAL_QUEUE                         CIRCBUF_QUEUE
-
-#if defined(__LINUX_ZYNQ__)
-#define PLK_VETH_NAME                                   "plk_veth" // name of net device in Linux
-#endif
 
 //==============================================================================
 // Data Link Layer (DLL) specific defines

--- a/stack/include/common/defaultcfg.h
+++ b/stack/include/common/defaultcfg.h
@@ -10,6 +10,7 @@ This file defines openPOWERLINK default configuration values.
 /*------------------------------------------------------------------------------
 Copyright (c) 2016, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
 Copyright (c) 2013, SYSTEC electronic GmbH
+Copyright (c) 2018, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -226,7 +227,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 #ifndef PLK_VETH_NAME
-#define PLK_VETH_NAME                                   "plk"               // name of net device in Linux
+#define PLK_VETH_NAME                                   "plk_veth"          // name of net device in Linux
 #endif
 
 #ifndef CONFIG_VETH_SET_DEFAULT_GATEWAY

--- a/stack/proj/linux/liboplkmnapp-kernelpcp/oplkcfg.h
+++ b/stack/proj/linux/liboplkmnapp-kernelpcp/oplkcfg.h
@@ -12,8 +12,7 @@ application libary on Linux which is using the kernelspace interface.
 /*------------------------------------------------------------------------------
 Copyright (c) 2012, SYSTEC electronik GmbH
 Copyright (c) 2017, Bernecker+Rainer Industrie-Elektronik Ges.m.b.H. (B&R)
-Copyright (c) 2017, Kalycito Infotech Private Limited
-
+Copyright (c) 2018, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -80,10 +79,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONFIG_VETH_SET_DEFAULT_GATEWAY                 FALSE
 
 #define CONFIG_CHECK_HEARTBEAT_PERIOD                   100        // 100 ms
-
-#if defined(__LINUX_ZYNQ__)
-#define PLK_VETH_NAME                                   "plk_veth" // name of net device in Linux
-#endif
 
 //==============================================================================
 // Data Link Layer (DLL) specific defines


### PR DESCRIPTION
 - This commit updates the net device name (PLK_VETH_NAME) as
   'plk_veth' to make it generic for all platforms.

This pull request supersedes #328.