### PR TITLE
edrv-rawsock_linux: add missing include for u_char type

### DIFF
--- a/stack/src/kernel/edrv/edrv-rawsock_linux.c
+++ b/stack/src/kernel/edrv/edrv-rawsock_linux.c
@@ -59,6 +59,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <arpa/inet.h>
 #include <ifaddrs.h>
 #include <linux/if_packet.h>
+#include <sys/types.h>
 
 //============================================================================//
 //            G L O B A L   D E F I N I T I O N S                             //


### PR DESCRIPTION
Fixes:

edrv/edrv-rawsock_linux.c:373:46: error: 'u_char' undeclared (first use in this function)

http://autobuild.buildroot.org/results/63d/63d5b21b5581f2005d6ca2bd0558601cc17eaee1/build-end.log

Signed-off-by: Romain Naour <romain.naour@smile.fr>