### PR TITLE
[FIX] Fix compilation errors for Linux kernel > v4.15

### DIFF
--- a/drivers/linux/drv_kernelmod_edrv/main.c
+++ b/drivers/linux/drv_kernelmod_edrv/main.c
@@ -11,7 +11,7 @@ the openPOWERLINK kernel stack.
 *******************************************************************************/
 /*------------------------------------------------------------------------------
 Copyright (c) 2016, B&R Industrial Automation GmbH
-Copyright (c) 2017, Kalycito Infotech Private Limited
+Copyright (c) 2018, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -157,7 +157,12 @@ static int          sendAsyncFrame(unsigned long arg_p);
 static int          writeErrorObject(unsigned long arg_p);
 static int          readErrorObject(unsigned long arg_p);
 
+#if (LINUX_VERSION_CODE <= KERNEL_VERSION(4,15,0))
 static void         increaseHeartbeatCb(ULONG data_p);
+#else
+static void         increaseHeartbeatCb(struct timer_list* data_p);
+#endif
+
 static void         startHeartbeatTimer(ULONG timeInMs_p);
 static void         stopHeartbeatTimer(void);
 
@@ -310,7 +315,13 @@ static int powerlinkOpen(struct inode* pInode_p,
         return -ENOTTY;
     }
 
+#if (LINUX_VERSION_CODE <= KERNEL_VERSION(4,15,0))
     init_timer(&heartbeatTimer_g);
+#else
+    /* timer_setup API is used instead of init_timer as it is deprecated
+     * in the new kernel */
+    timer_setup(&heartbeatTimer_g, increaseHeartbeatCb, 0);
+#endif
 
     if (ctrlk_init(NULL) != kErrorOk)
     {
@@ -930,8 +941,11 @@ The function starts the timer used for updating the heartbeat counter.
 //------------------------------------------------------------------------------
 void startHeartbeatTimer(ULONG timeInMs_p)
 {
+#if (LINUX_VERSION_CODE <= KERNEL_VERSION(4,15,0))
     heartbeatTimer_g.function = increaseHeartbeatCb;
     heartbeatTimer_g.data = 0;
+#endif
+
     heartbeatTimer_g.expires = jiffies + (timeInMs_p * HZ / 1000);
     add_timer(&heartbeatTimer_g);
 }
@@ -962,7 +976,12 @@ heartbeat counter.
 \ingroup module_driver_linux_kernel
 */
 //------------------------------------------------------------------------------
+#if (LINUX_VERSION_CODE <= KERNEL_VERSION(4,15,0))
 void increaseHeartbeatCb(ULONG data_p)
+#else
+/* Modified increaseHeartbeatCb to handle callback functionality */
+void increaseHeartbeatCb(struct timer_list* data_p)
+#endif
 {
     UNUSED_PARAMETER(data_p);
 

--- a/stack/src/kernel/event/eventkcal-linuxkernel.c
+++ b/stack/src/kernel/event/eventkcal-linuxkernel.c
@@ -14,6 +14,7 @@ kernelspace platform. It uses the circular buffer interface for all event queues
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2016, B&R Industrial Automation GmbH
+Copyright (c) 2018, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -55,6 +56,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <linux/sched.h>
 #include <linux/cpumask.h>
 #include <linux/uaccess.h>
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0))
+/* Included types.h header to link sched_param structure */
+#include <linux/sched/types.h>
+#endif
+
 #include <asm/uaccess.h>
 #include <asm/atomic.h>
 


### PR DESCRIPTION
 - init_timer() is deprecated in new kernels hence add
   timer_setup() to support for kernel > v4.15
 - This fix resolves compilation error for Linux Edrv designs

**Test configuration:**
_Cycle Time:_ 50ms
_No. of CNs:_ 3 (1,32,110)

**Tested platforms:**

- 8255x (Kernel Version – 3.12.24-rt38) 
- 82567 & 82573 (Kernel Version – 4.8.15-rt10) 
- 8139 (Kernel Version – 4.16.15-rt7) 
- i210 (Kernel Version – 4.16.15-rt7) 
- 8111 (Kernel Version – 3.12.24-rt38)

Performance test scenarios are not validated.

This fix resolves #352.
