### PR TITLE
[FIX] Fix for RMN support in Zynq Emacps

### DIFF
--- a/stack/src/kernel/edrv/edrv-emacps.c
+++ b/stack/src/kernel/edrv/edrv-emacps.c
@@ -11,7 +11,7 @@ the EMACPS Gigabit Ethernet Controller (GEM) on the Xilinx Zynq SoC.
 *******************************************************************************/
 
 /*------------------------------------------------------------------------------
-Copyright (c) 2014, Kalycito Infotech Pvt. Ltd.
+Copyright (c) 2018, Kalycito Infotech Private Limited
 Copyright (c) 2017, B&R Industrial Automation GmbH
 All rights reserved.
 
@@ -473,7 +473,7 @@ tOplkError edrv_setRxMulticastMacAddr(const UINT8* pMacAddr_p)
     hashValue = calculateHashAddr(pMacAddr_p);
 
     hashRegLVal = EDRV_READ_REG(EDRV_HASHL_REG);
-    hashRegHVal = EDRV_READ_REG(EDRV_HASHL_REG);
+    hashRegHVal = EDRV_READ_REG(EDRV_HASHH_REG);
 
     if (hashValue < 32)
     {
@@ -516,7 +516,7 @@ tOplkError edrv_clearRxMulticastMacAddr(const UINT8* pMacAddr_p)
     hashValue = calculateHashAddr(pMacAddr_p);
 
     hashRegLVal = EDRV_READ_REG(EDRV_HASHL_REG);
-    hashRegHVal = EDRV_READ_REG(EDRV_HASHL_REG);
+    hashRegHVal = EDRV_READ_REG(EDRV_HASHH_REG);
 
     if (hashValue < 32)
     {


### PR DESCRIPTION
 - Fix the register read/write functionality in
   edrv_setRxMulticastMacAddr API and
   edrv_clearRxMulticastMacAddr API
 - Need to configure the objects 1C0Bh and 1C0Dh in
   openCONFIGURATOR with optimum values to fix the
   stability issues of SMN

Changing actual value of objects, 1C0B/03 and 1C0D/03 as other CN's in the Network along with this fix will resolve RMN issue in Zynq Emacps design.

This pull request resolves #316 for Zynq EmacPS design.