### PR TITLE
stack/src/kernel/edrv/edrv-rawsock_linux.c: add missing <sys/types.h>…

### DIFF
--- a/stack/src/kernel/edrv/edrv-rawsock_linux.c
+++ b/stack/src/kernel/edrv/edrv-rawsock_linux.c
@@ -59,6 +59,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <arpa/inet.h>
 #include <ifaddrs.h>
 #include <linux/if_packet.h>
+#include <sys/types.h>
 
 //============================================================================//
 //            G L O B A L   D E F I N I T I O N S                             //


### PR DESCRIPTION
… include

This is necessary to get the definition of the u_char type, otherwise
the build fails with the musl C library with:

stack/src/kernel/edrv/edrv-rawsock_linux.c:373:46: error: ‘u_char’ undeclared (first use in this function)

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>