### PR TITLE
[FIX] Fix Windows NDIS & PCIe Basic run issue

### DIFF
--- a/stack/include/common/pdo.h
+++ b/stack/include/common/pdo.h
@@ -9,6 +9,7 @@
 /*------------------------------------------------------------------------------
 Copyright (c) 2012, SYSTEC electronic GmbH
 Copyright (c) 2017, B&R Industrial Automation GmbH
+Copyright (c) 2018, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -93,9 +94,8 @@ PDO channel information between the user and the kernel layer.
 */
 typedef struct
 {
-    UINT8               channelId;              ///< ID of the PDO channel
+    UINT                channelId;              ///< ID of the PDO channel
     BOOL                fTx;                    ///< Flag determines the direction. TRUE = TPDO, FALSE = RPDO
-    UINT8               aPadding[2];            ///< Padding for 32 bit alignment
     tPdoChannel         pdoChannel;             ///< The PDO channel itself
 } tPdoChannelConf;
 

--- a/stack/include/kernel/dllkfilter.h
+++ b/stack/include/kernel/dllkfilter.h
@@ -12,6 +12,7 @@ can only be used for MACs which have a frame filter.
 /*------------------------------------------------------------------------------
 Copyright (c) 2013, SYSTEC electronic GmbH
 Copyright (c) 2016, B&R Industrial Automation GmbH
+Copyright (c) 2018, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -92,7 +93,7 @@ extern "C"
 
 void dllkfilter_setupFilters(void);
 void dllkfilter_setupPresFilter(tEdrvFilter* pFilter_p, BOOL fEnable_p);
-void dllkfilter_setupPreqFilter(tEdrvFilter* pFilter_p, UINT8 nodeId_p,
+void dllkfilter_setupPreqFilter(tEdrvFilter* pFilter_p, UINT nodeId_p,
                                 tEdrvTxBuffer* pBuffer_p,
                                 const UINT8* pMacAdrs_p);
 

--- a/stack/include/kernel/pdoklut.h
+++ b/stack/include/kernel/pdoklut.h
@@ -9,6 +9,7 @@ This file contains the definitions needed by the PDO lookup table module.
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2017, B&R Industrial Automation GmbH
+Copyright (c) 2018, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -77,7 +78,7 @@ extern "C"
 void       pdoklut_clear(tPdoklutEntry* pLut_p, size_t numEntries_p);
 tOplkError pdoklut_addChannel(tPdoklutEntry* pLut_p,
                               const tPdoChannel* pPdoChannel_p,
-                              UINT8 channelId_p);
+                              UINT channelId_p);
 UINT8      pdoklut_getChannel(const tPdoklutEntry* pLut_p,
                               UINT8 index_p,
                               UINT8 nodeId_p)

--- a/stack/include/oplk/dll.h
+++ b/stack/include/oplk/dll.h
@@ -11,6 +11,7 @@ This file contains the definitions for the DLL module.
 /*------------------------------------------------------------------------------
 Copyright (c) 2013, SYSTEC electronic GmbH
 Copyright (c) 2016, B&R Industrial Automation GmbH
+Copyright (c) 2018, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -179,8 +180,8 @@ This struct provides information about the unreceived Asnd frame.
 */
 typedef struct
 {
-    UINT8   nodeId;         ///< Source node ID of missed Asnd frame
-    UINT8   serviceId;      ///< Service ID of missed Asnd frame
+    BYTE    nodeId;         ///< Source node ID of missed Asnd frame
+    BYTE    serviceId;      ///< Service ID of missed Asnd frame
 } tDllAsndNotRx;
 
 /**
@@ -191,28 +192,26 @@ the data link layer (DLL).
 */
 typedef struct
 {
-    UINT32              sizeOfStruct;               ///< Size of the structure
+    UINT                sizeOfStruct;               ///< Size of the structure
     BOOL                fAsyncOnly;                 ///< Async only node, does not need to register PRes-Frame
-    UINT8               nodeId;                     ///< Local node ID
-    UINT8               padding0[3];                ///< Padding to 32 bit boundary
+    UINT                nodeId;                     ///< Local node ID
     UINT32              featureFlags;               ///< 0x1F82: NMT_FeatureFlags_U32
     UINT32              cycleLen;                   ///< Cycle Length (0x1006: NMT_CycleLen_U32) in [us], required for error detection
-    UINT16              isochrTxMaxPayload;         ///< 0x1F98.1: IsochrTxMaxPayload_U16
-    UINT16              isochrRxMaxPayload;         ///< 0x1F98.2: IsochrRxMaxPayload_U16
+    UINT                isochrTxMaxPayload;         ///< 0x1F98.1: IsochrTxMaxPayload_U16
+    UINT                isochrRxMaxPayload;         ///< 0x1F98.2: IsochrRxMaxPayload_U16
     UINT32              presMaxLatency;             ///< 0x1F98.3: PResMaxLatency_U32 in [ns], only required for IdentRes
-    UINT16              preqActPayloadLimit;        ///< 0x1F98.4: PReqActPayloadLimit_U16, required for initialization (+24 bytes)
-    UINT16              presActPayloadLimit;        ///< 0x1F98.5: PResActPayloadLimit_U16, required for initialization of Pres frame (+24 bytes)
+    UINT                preqActPayloadLimit;        ///< 0x1F98.4: PReqActPayloadLimit_U16, required for initialization (+24 bytes)
+    UINT                presActPayloadLimit;        ///< 0x1F98.5: PResActPayloadLimit_U16, required for initialization of Pres frame (+24 bytes)
     UINT32              asndMaxLatency;             ///< 0x1F98.6: ASndMaxLatency_U32 in [ns], only required for IdentRes
-    UINT8               multipleCycleCnt;           ///< 0x1F98.7: MultiplCycleCnt_U8, required for error detection
-    UINT8               padding1[3];                ///< Padding to 32 bit boundary
-    UINT16              asyncMtu;                   ///< 0x1F98.8: AsyncMTU_U16, required to set up max frame size
-    UINT16              prescaler;                  ///< 0x1F98.9: Prescaler_U16, configures the toggle rate of the SoC PS flag
+    UINT                multipleCycleCnt;           ///< 0x1F98.7: MultiplCycleCnt_U8, required for error detection
+    UINT                asyncMtu;                   ///< 0x1F98.8: AsyncMTU_U16, required to set up max frame size
+    UINT                prescaler;                  ///< 0x1F98.9: Prescaler_U16, configures the toggle rate of the SoC PS flag
     // $$$ Multiplexed Slot
     UINT32              lossOfFrameTolerance;       ///< 0x1C14: DLL_LossOfFrameTolerance_U32 in [ns]
     UINT32              waitSocPreq;                ///< 0x1F8A.1: WaitSoCPReq_U32 in [ns]
     UINT32              asyncSlotTimeout;           ///< 0x1F8A.2: AsyncSlotTimeout_U32 in [ns]
     UINT32              syncResLatency;             ///< Constant response latency for SyncRes in [ns]
-    UINT32              syncNodeId;                 ///< Synchronization trigger (AppCbSync, cycle preparation) after PRes from CN with this node-ID (0 = SoC, 255 = SoA)
+    UINT                syncNodeId;                 ///< Synchronization trigger (AppCbSync, cycle preparation) after PRes from CN with this node-ID (0 = SoC, 255 = SoA)
     BOOL                fSyncOnPrcNode;             ///< TRUE: CN is PRes chained; FALSE: conventional CN (PReq/PRes)
 #if defined(CONFIG_INCLUDE_NMT_RMN)
     UINT32              switchOverTimeMn;           ///< Switch over time when CS_OPERATIONAL in [us]
@@ -230,7 +229,7 @@ node on the network.
 */
 typedef struct
 {
-    UINT32              sizeOfStruct;                   ///< Size of the structure
+    UINT                sizeOfStruct;                   ///< Size of the structure
     UINT32              deviceType;                     ///< NMT_DeviceType_U32
     UINT32              vendorId;                       ///< NMT_IdentityObject_REC.VendorId_U32
     UINT32              productCode;                    ///< NMT_IdentityObject_REC.ProductCode_U32

--- a/stack/src/kernel/dll/dllk.c
+++ b/stack/src/kernel/dll/dllk.c
@@ -12,7 +12,7 @@ This file contains the implementation of the DLL kernel module.
 /*------------------------------------------------------------------------------
 Copyright (c) 2015, SYSTEC electronic GmbH
 Copyright (c) 2017, B&R Industrial Automation GmbH
-Copyright (c) 2017, Kalycito Infotech Private Limited
+Copyright (c) 2018, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -547,16 +547,24 @@ tOplkError dllk_configNode(const tDllNodeInfo* pNodeInfo_p)
 
     // copy node configuration
     if (pNodeInfo_p->presPayloadLimit > dllkInstance_g.dllConfigParam.isochrRxMaxPayload)
-        pIntNodeInfo->presPayloadLimit = dllkInstance_g.dllConfigParam.isochrRxMaxPayload;
+    {
+        pIntNodeInfo->presPayloadLimit = (UINT16)dllkInstance_g.dllConfigParam.isochrRxMaxPayload;
+    }
     else
+    {
         pIntNodeInfo->presPayloadLimit = pNodeInfo_p->presPayloadLimit;
+    }
 
 #if defined(CONFIG_INCLUDE_NMT_MN)
     pIntNodeInfo->presTimeoutNs = pNodeInfo_p->presTimeoutNs;
     if (pNodeInfo_p->preqPayloadLimit > dllkInstance_g.dllConfigParam.isochrTxMaxPayload)
-        pIntNodeInfo->preqPayloadLimit = dllkInstance_g.dllConfigParam.isochrTxMaxPayload;
+    {
+        pIntNodeInfo->preqPayloadLimit = (UINT16)dllkInstance_g.dllConfigParam.isochrTxMaxPayload;
+    }
     else
+    {
         pIntNodeInfo->preqPayloadLimit = pNodeInfo_p->preqPayloadLimit;
+    }
 
     // initialize elements of internal node info structure
     pIntNodeInfo->soaFlag1 = PLK_FRAME_FLAG1_ER;

--- a/stack/src/kernel/dll/dllkfilter.c
+++ b/stack/src/kernel/dll/dllkfilter.c
@@ -12,6 +12,7 @@ This file contains the functions to setup the edrv filter structures.
 /*------------------------------------------------------------------------------
 Copyright (c) 2013, SYSTEC electronic GmbH
 Copyright (c) 2016, B&R Industrial Automation GmbH
+Copyright (c) 2018, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -137,13 +138,13 @@ void dllkfilter_setupFilters(void)
     setupSocFilter(&dllkInstance_g.aFilter[DLLK_FILTER_SOC]);
     setupSoaFilter(&dllkInstance_g.aFilter[DLLK_FILTER_SOA]);
     setupSoaIdentReqFilter(&dllkInstance_g.aFilter[DLLK_FILTER_SOA_IDREQ],
-                           dllkInstance_g.dllConfigParam.nodeId,
+                           (UINT8)dllkInstance_g.dllConfigParam.nodeId,
                            &dllkInstance_g.pTxBuffer[DLLK_TXFRAME_IDENTRES]);
     setupSoaStatusReqFilter(&dllkInstance_g.aFilter[DLLK_FILTER_SOA_STATREQ],
-                            dllkInstance_g.dllConfigParam.nodeId,
+                            (UINT8)dllkInstance_g.dllConfigParam.nodeId,
                             &dllkInstance_g.pTxBuffer[DLLK_TXFRAME_STATUSRES]);
     setupSoaNmtReqFilter(&dllkInstance_g.aFilter[DLLK_FILTER_SOA_NMTREQ],
-                         dllkInstance_g.dllConfigParam.nodeId,
+                         (UINT8)dllkInstance_g.dllConfigParam.nodeId,
                          &dllkInstance_g.pTxBuffer[DLLK_TXFRAME_NMTREQ]);
 #if (CONFIG_DLL_PRES_CHAINING_CN != FALSE)
     setupSoaSyncReqFilter(&dllkInstance_g.aFilter[DLLK_FILTER_SOA_SYNCREQ],
@@ -151,7 +152,7 @@ void dllkfilter_setupFilters(void)
                           &dllkInstance_g.pTxBuffer[DLLK_TXFRAME_SYNCRES]);
 #endif
     setupSoaUnspecReqFilter(&dllkInstance_g.aFilter[DLLK_FILTER_SOA_NONPLK],
-                            dllkInstance_g.dllConfigParam.nodeId,
+                            (UINT8)dllkInstance_g.dllConfigParam.nodeId,
                             &dllkInstance_g.pTxBuffer[DLLK_TXFRAME_NONPLK]);
 #if defined(CONFIG_INCLUDE_VETH)
     setupVethUnicast(&dllkInstance_g.aFilter[DLLK_FILTER_VETH_UNICAST],
@@ -200,7 +201,7 @@ The function sets up an PReq filter in the Edrv filter structure.
 */
 //------------------------------------------------------------------------------
 void dllkfilter_setupPreqFilter(tEdrvFilter* pFilter_p,
-                                UINT8 nodeId_p,
+                                UINT nodeId_p,
                                 tEdrvTxBuffer* pBuffer_p,
                                 const UINT8* pMacAdrs_p)
 {
@@ -215,7 +216,7 @@ void dllkfilter_setupPreqFilter(tEdrvFilter* pFilter_p,
     ami_setUint16Be(&pFilter_p->aFilterMask[12], 0xFFFF);
     ami_setUint8Be(&pFilter_p->aFilterValue[14], kMsgTypePreq);
     ami_setUint8Be(&pFilter_p->aFilterMask[14], 0xFF);
-    ami_setUint8Be(&pFilter_p->aFilterValue[15], nodeId_p);
+    ami_setUint8Be(&pFilter_p->aFilterValue[15], (UINT8)nodeId_p);
     ami_setUint8Be(&pFilter_p->aFilterMask[15], 0xFF);
     ami_setUint8Be(&pFilter_p->aFilterValue[16], C_ADR_MN_DEF_NODE_ID);
     ami_setUint8Be(&pFilter_p->aFilterMask[16], 0xFF);

--- a/stack/src/kernel/dll/dllkframe.c
+++ b/stack/src/kernel/dll/dllkframe.c
@@ -12,6 +12,7 @@ This file contains the frame processing functions of the kernel DLL module.
 /*------------------------------------------------------------------------------
 Copyright (c) 2018, B&R Industrial Automation GmbH
 Copyright (c) 2015, SYSTEC electronic GmbH
+Copyright (c) 2018, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -700,7 +701,7 @@ tOplkError dllkframe_checkFrame(tPlkFrame* pFrame_p, size_t frameSize_p)
         if (etherType == C_DLL_ETHERTYPE_EPL)
         {
             // source node ID
-            ami_setUint8Le(&pFrame_p->srcNodeId, dllkInstance_g.dllConfigParam.nodeId);
+            ami_setUint8Le(&pFrame_p->srcNodeId, (UINT8)dllkInstance_g.dllConfigParam.nodeId);
 
             // check message type
             msgType = (tMsgType)ami_getUint8Le(&pFrame_p->messageType);
@@ -879,7 +880,7 @@ tOplkError dllkframe_createTxFrame(UINT* pHandle_p,
         if (msgType_p != kMsgTypeNonPowerlink)
         {   // fill out Frame only if it is a POWERLINK frame
             ami_setUint16Be(&pTxFrame->etherType, C_DLL_ETHERTYPE_EPL);
-            ami_setUint8Le(&pTxFrame->srcNodeId, dllkInstance_g.dllConfigParam.nodeId);
+            ami_setUint8Le(&pTxFrame->srcNodeId, (UINT8)dllkInstance_g.dllConfigParam.nodeId);
             OPLK_MEMCPY(&pTxFrame->aSrcMac[0], edrv_getMacAddr(), 6);
 
             switch (msgType_p)
@@ -896,11 +897,11 @@ tOplkError dllkframe_createTxFrame(UINT* pHandle_p,
                             ami_setUint32Le(&pTxFrame->data.asnd.payload.identResponse.featureFlagsLe,
                                             dllkInstance_g.dllConfigParam.featureFlags);
                             ami_setUint16Le(&pTxFrame->data.asnd.payload.identResponse.mtuLe,
-                                            dllkInstance_g.dllConfigParam.asyncMtu);
+                                            (UINT16)dllkInstance_g.dllConfigParam.asyncMtu);
                             ami_setUint16Le(&pTxFrame->data.asnd.payload.identResponse.pollInSizeLe,
-                                            dllkInstance_g.dllConfigParam.preqActPayloadLimit);
+                                            (UINT16)dllkInstance_g.dllConfigParam.preqActPayloadLimit);
                             ami_setUint16Le(&pTxFrame->data.asnd.payload.identResponse.pollOutSizeLe,
-                                            dllkInstance_g.dllConfigParam.presActPayloadLimit);
+                                            (UINT16)dllkInstance_g.dllConfigParam.presActPayloadLimit);
                             ami_setUint32Le(&pTxFrame->data.asnd.payload.identResponse.responseTimeLe,
                                             dllkInstance_g.dllConfigParam.presMaxLatency);
                             ami_setUint32Le(&pTxFrame->data.asnd.payload.identResponse.deviceTypeLe,

--- a/stack/src/kernel/pdo/pdoklut.c
+++ b/stack/src/kernel/pdo/pdoklut.c
@@ -12,6 +12,7 @@ used for fast searching of PDO channels for a specific node.
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2017, B&R Industrial Automation GmbH
+Copyright (c) 2018, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -132,11 +133,11 @@ This function adds a new PDO channel to the lookup table.
 //------------------------------------------------------------------------------
 tOplkError pdoklut_addChannel(tPdoklutEntry* pLut_p,
                               const tPdoChannel* pPdoChannel_p,
-                              UINT8 channelId_p)
+                              UINT channelId_p)
 {
     tOplkError      ret = kErrorIllegalInstance;
     int             i;
-    UINT8           nodeId;
+    UINT            nodeId;
 
     // Check parameter validity
     ASSERT(pLut_p != NULL);


### PR DESCRIPTION
 - Remove padding data for 32 bit alignment

This pull request addresses comments from #369 and supersedes the same. 
Pull request #369 contains commit for 

1. Remove padding data for 32 bit alignment
2. Fix output path for driver build

Review comment in #369 was to have 2 separate commits. This pull request contains commit to resolve 1st issue.
**Kind Note:** In file dllkframce.c file, line length is exceeding 100 characters. But this cannot be taken to a separate line. Hence vera++ errors are ignored here.

FYI, basic run test is tested in all platforms in #369 and found no issues. So this pull request shall be merged.

