### PR TITLE
[FIX] Fix output path for NDIS driver build

### DIFF
--- a/drivers/windows/drv_ndis_intermediate/build/drv_ndis_intermediate_package/drv_ndis_intermediate_package.vcxproj
+++ b/drivers/windows/drv_ndis_intermediate/build/drv_ndis_intermediate_package/drv_ndis_intermediate_package.vcxproj
@@ -74,8 +74,7 @@
     <VerifyProjectOutput>True</VerifyProjectOutput>
     <VerifyDrivers />
     <VerifyFlags>133563</VerifyFlags>
-    <OutDir>$(SolutionDir)..\..\..\..\bin\windows\$(PROCESSOR_ARCHITECTURE)\</OutDir>
-    <IntDir>$(Platform)\$(ConfigurationName)\</IntDir>
+    <OutDir>$(SolutionDir)..\..\..\..\bin\windows\x86\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win7 Release|Win32'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
@@ -89,8 +88,7 @@
     <VerifyProjectOutput>True</VerifyProjectOutput>
     <VerifyDrivers />
     <VerifyFlags>133563</VerifyFlags>
-    <OutDir>$(SolutionDir)..\..\..\..\bin\windows\$(PROCESSOR_ARCHITECTURE)\</OutDir>
-    <IntDir>$(Platform)\$(ConfigurationName)\</IntDir>
+    <OutDir>$(SolutionDir)..\..\..\..\bin\windows\x86\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win7 Debug|x64'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
@@ -104,7 +102,7 @@
     <VerifyProjectOutput>True</VerifyProjectOutput>
     <VerifyDrivers />
     <VerifyFlags>133563</VerifyFlags>
-    <OutDir>$(SolutionDir)..\..\..\..\bin\windows\$(PROCESSOR_ARCHITEW6432)\</OutDir>
+    <OutDir>$(SolutionDir)..\..\..\..\bin\windows\amd64\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win7 Release|x64'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
@@ -118,12 +116,15 @@
     <VerifyProjectOutput>True</VerifyProjectOutput>
     <VerifyDrivers />
     <VerifyFlags>133563</VerifyFlags>
-    <OutDir>$(SolutionDir)..\..\..\..\bin\windows\$(PROCESSOR_ARCHITEW6432)\</OutDir>
+    <OutDir>$(SolutionDir)..\..\..\..\bin\windows\amd64\</OutDir>
   </PropertyGroup>
   <ItemGroup>
     <FilesToPackage Include="@(Inf->'%(CopyOutput)')" Condition="'@(Inf)'!=''" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\drv_ndis_intermediate\drv_ndis_intermediate.vcxproj">
+      <Project>{be53555d-b97e-480a-9cab-29aa58d34d00}</Project>
+    </ProjectReference>
     <ProjectReference Include="..\notifyObj\notifyObj.vcxproj">
       <Project>{293ba7ca-111d-4125-864a-ad5edd9de5cc}</Project>
     </ProjectReference>

--- a/drivers/windows/drv_ndis_intermediate/build/notifyObj/notifyObj.vcxproj
+++ b/drivers/windows/drv_ndis_intermediate/build/notifyObj/notifyObj.vcxproj
@@ -102,7 +102,7 @@
       <InterfaceIdentifierFileName>notifyObj_i.c</InterfaceIdentifierFileName>
       <ProxyFileName>notifyObj_p.c</ProxyFileName>
       <GenerateStublessProxies>true</GenerateStublessProxies>
-      <TypeLibraryName>$(IntDir)notifyObj.tlb</TypeLibraryName>
+      <TypeLibraryName>notifyObj.tlb</TypeLibraryName>
       <DllDataFileName />
       <OutputDirectory>$(IntDir)</OutputDirectory>
       <ValidateAllParameters>true</ValidateAllParameters>

--- a/tools/windows/installer-ndisim/build/installer-ndisim.vcxproj
+++ b/tools/windows/installer-ndisim/build/installer-ndisim.vcxproj
@@ -112,8 +112,8 @@ copy  $(OutputPath)$(TargetFileName) $(SolutionDir)..\..\..\..\bin\windows\x86\$
       <AdditionalDependencies>setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;Cfgmgr32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>mkdir $(SolutionDir)..\..\..\..\bin\windows\$(PROCESSOR_ARCHITEW6432)\$(SolutionName)\
-copy  $(OutputPath)$(TargetFileName) $(SolutionDir)..\..\..\..\bin\windows\$(PROCESSOR_ARCHITEW6432)\$(SolutionName)\</Command>
+      <Command>mkdir $(SolutionDir)..\..\..\..\bin\windows\amd64\$(SolutionName)\
+copy  $(OutputPath)$(TargetFileName) $(SolutionDir)..\..\..\..\bin\windows\amd64\$(SolutionName)\</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -158,8 +158,8 @@ copy  $(OutputPath)$(TargetFileName) $(SolutionDir)..\..\..\..\bin\windows\x86\$
       <AdditionalDependencies>setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;Cfgmgr32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>mkdir $(SolutionDir)..\..\..\..\bin\windows\$(PROCESSOR_ARCHITEW6432)\$(SolutionName)\
-copy  $(OutputPath)$(TargetFileName) $(SolutionDir)..\..\..\..\bin\windows\$(PROCESSOR_ARCHITEW6432)\$(SolutionName)\</Command>
+      <Command>mkdir $(SolutionDir)..\..\..\..\bin\windows\amd64\$(SolutionName)\
+copy  $(OutputPath)$(TargetFileName) $(SolutionDir)..\..\..\..\bin\windows\amd64\$(SolutionName)\</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
This pull request addresses comments from #369 and supersedes the same.
Pull request #369 contains commit for

1. Remove padding data for 32 bit alignment
2. Fix output path for driver build

Review comment in #369 was to have 2 separate commits. This pull request contains commit to resolve 2nd issue.
This pull request is tested and the output path is verified.

**Kind Note:** Basic run for Windows NDIS and PCIe will not work if #377 is not merged.