### PR TITLE
[FIX] Doxygen Enhancement

### DIFF
--- a/doc/build-drivers.md
+++ b/doc/build-drivers.md
@@ -63,10 +63,17 @@ To build the kernel space driver, the appropriate kernel sources must be install
 on your system. The path to the kernel sources can be configured by
 __CFG_KERNEL_DIR__.
 
-To build the kernel interface driver for Zynq hybrid:
+To build the kernel interface driver for Zynq hybrid MN:
 
       > cd <openPOWERLINK_dir>/drivers/linux/drv_kernelmod_zynq/build
       > cmake -DCFG_OPLK_MN=TRUE -CMAKE_TOOLCHAIN_FILE=<openPOWERLINK_dir>/cmake/toolchain-xilinx-vivado-arm-linux-eabi-gnu.cmake ..
+      > make
+      > make install
+
+To build the kernel interface driver for Zynq hybrid CN:
+
+      > cd <openPOWERLINK_dir>/drivers/linux/drv_kernelmod_zynq/build
+      > cmake -DCFG_OPLK_MN=FALSE -CMAKE_TOOLCHAIN_FILE=<openPOWERLINK_dir>/cmake/toolchain-xilinx-vivado-arm-linux-eabi-gnu.cmake ..
       > make
       > make install
 
@@ -138,19 +145,35 @@ This section will explain the steps to build the PCP daemon for a Microblaze
 softcore processor with host interface by using the Vivado toolchain.
 The PCP daemon uses the driver library for the host interface (`liboplkmndrv-dualprocshm`).
 
-To build the PCP daemon:
+To build the MN PCP daemon:
 
   * On a Windows host platform
 
         > cd <openPOWERLINK_dir>/drivers/xilinx-microblaze/drv_daemon/build
-        > cmake -GUnix\ Makefiles -DCMAKE_TOOLCHAIN_FILE=../../../../cmake/toolchain-xilinx-microblaze-gnu.cmake -DCMAKE_BUILD_TYPE=Release -DCFG_BUILD_KERNEL_STACK="PCP Daemon Dual-Proc" ..
+        > cmake -GUnix\ Makefiles -DCMAKE_TOOLCHAIN_FILE=../../../../cmake/toolchain-xilinx-microblaze-gnu.cmake -DCMAKE_BUILD_TYPE=Release -DCFG_BUILD_KERNEL_STACK="PCP Daemon Dual-Proc" -DCFG_HW_LIB=xilinx-z702/mn-dual-shmem-gpio ..
         > make
         > make install
 
   * On a Linux host platform
 
         > cd <openPOWERLINK_dir>/drivers/xilinx-microblaze/drv_daemon/build
-        > cmake -DCMAKE_TOOLCHAIN_FILE=../../../../cmake/toolchain-xilinx-microblaze-gnu.cmake -DCMAKE_BUILD_TYPE=Release -DCFG_BUILD_KERNEL_STACK="PCP Daemon Dual-Proc" ..
+        > cmake -GUnix\ Makefiles -DCMAKE_TOOLCHAIN_FILE=../../../../cmake/toolchain-xilinx-microblaze-gnu.cmake -DCMAKE_BUILD_TYPE=Release -DCFG_BUILD_KERNEL_STACK="PCP Daemon Dual-Proc" -DCFG_HW_LIB=xilinx-z702/mn-dual-shmem-gpio ..
+        > make
+        > make install
+
+To build the CN PCP daemon:
+
+  * On a Windows host platform
+
+        > cd <openPOWERLINK_dir>/drivers/xilinx-microblaze/drv_daemon/build
+        > cmake -GUnix\ Makefiles -DCMAKE_TOOLCHAIN_FILE=../../../../cmake/toolchain-xilinx-microblaze-gnu.cmake -DCMAKE_BUILD_TYPE=Release -DCFG_BUILD_KERNEL_STACK="PCP Daemon Dual-Proc" -DCFG_HW_LIB=xilinx-z702/cn-dual-shmem-gpio -DCFG_OPLK_MN=OFF ..
+        > make
+        > make install
+
+  * On a Linux host platform
+
+        > cd <openPOWERLINK_dir>/drivers/xilinx-microblaze/drv_daemon/build
+        > cmake -GUnix\ Makefiles -DCMAKE_TOOLCHAIN_FILE=../../../../cmake/toolchain-xilinx-microblaze-gnu.cmake -DCMAKE_BUILD_TYPE=Release -DCFG_BUILD_KERNEL_STACK="PCP Daemon Dual-Proc" -DCFG_HW_LIB=xilinx-z702/cn-dual-shmem-gpio -DCFG_OPLK_MN=OFF ..
         > make
         > make install
 

--- a/doc/build-hardware.md
+++ b/doc/build-hardware.md
@@ -91,7 +91,7 @@ hardware-dependent drivers.
 
 -# Build hardware platform with all driver libraries set to debug
 
-        > cmake ../.. -DCMAKE_BUILD_TYPE=Debug -DDEMO_[BOARD_NAME]_[DEMO_NAME]=ON
+        > cmake ../.. -DCMAKE_BUILD_TYPE=Debug -DSKIP_BITSTREAM=OFF -DDEMO_[BOARD_NAME]_[DEMO_NAME]=ON
         > make
         > make install
 
@@ -100,7 +100,7 @@ hardware-dependent drivers.
 
 -# Build hardware platforms with all driver libraries set to release
 
-        > cmake ../.. -DCMAKE_BUILD_TYPE=Release -DDEMO_[BOARD_NAME]_[DEMO_NAME]=ON
+        > cmake ../.. -DCMAKE_BUILD_TYPE=Release -DSKIP_BITSTREAM=OFF -DDEMO_[BOARD_NAME]_[DEMO_NAME]=ON
         > make
         > make install
 

--- a/doc/build-stack.md
+++ b/doc/build-stack.md
@@ -122,42 +122,36 @@ Follow the steps below to build the stack library on your host platform:
   * On a Windows host platform
 
         > cd <openPOWERLINK_dir>\stack\build\xilinx-microblaze
-        > cmake -GUnix\ Makefiles -DCMAKE_TOOLCHAIN_FILE=../../../cmake/toolchain-xilinx-microblaze-gnu.cmake ../.. -DCMAKE_BUILD_TYPE=Debug -DCFG_COMPILE_LIB_[LIB_NAME]=ON -DCFG_COMPILE_LIB_[LIB_NAME]_LIB_DIR=[PATH_TO_HW_LIB]
+        > cmake -GUnix\ Makefiles -DCMAKE_TOOLCHAIN_FILE=../../../cmake/toolchain-xilinx-microblaze-gnu.cmake ../.. -DCMAKE_BUILD_TYPE=Debug -DCFG_COMPILE_LIB_[LIB_NAME]=ON
         > make all
         > make install
 
   * On a Linux host platform
 
         > cd <openPOWERLINK_dir>\stack\build\xilinx-microblaze
-        > cmake -DCMAKE_TOOLCHAIN_FILE=../../../cmake/toolchain-xilinx-microblaze-gnu.cmake ../.. -DCMAKE_BUILD_TYPE=Debug -DCFG_COMPILE_LIB_[LIB_NAME]=ON -DCFG_COMPILE_LIB_[LIB_NAME]_LIB_DIR=[PATH_TO_HW_LIB]
+        > cmake -GUnix\ Makefiles -DCMAKE_TOOLCHAIN_FILE=../../../cmake/toolchain-xilinx-microblaze-gnu.cmake ../.. -DCMAKE_BUILD_TYPE=Debug -DCFG_COMPILE_LIB_[LIB_NAME]=ON
         > make all
         > make install
 
-  This will create the `[LIB_NAME]` stack library (debug) for the hardware library in `[PATH_TO_HW_LIB]`.
-  Multiple stack libraries can be built together by passing the define pairs (`CFG_COMPILE_LIB_[LIB_NAME]`
-  and `CFG_COMPILE_LIB_[LIB_NAME]_LIB_DIR`) for each stack library to CMake.
-  Refer to \ref sect_build_stack_options_noos_microblaze for details!
+  This will create the `[LIB_NAME]` stack library (debug) for the hardware library
 
 * Create release libraries
 
   * On a Windows host platform
 
         > cd <openPOWERLINK_dir>\stack\build\xilinx-microblaze
-        > cmake -GUnix\ Makefiles -DCMAKE_TOOLCHAIN_FILE=../../../cmake/toolchain-xilinx-microblaze-gnu.cmake ../.. -DCMAKE_BUILD_TYPE=Release -DCFG_COMPILE_LIB_[LIB_NAME]=ON -DCFG_COMPILE_LIB_[LIB_NAME]_LIB_DIR=[PATH_TO_HW_LIB]
+        > cmake -GUnix\ Makefiles -DCMAKE_TOOLCHAIN_FILE=../../../cmake/toolchain-xilinx-microblaze-gnu.cmake ../.. -DCMAKE_BUILD_TYPE=Release -DCFG_COMPILE_LIB_[LIB_NAME]=ON
         > make all
         > make install
 
   * On a Linux host platform
 
         > cd <openPOWERLINK_dir>\stack\build\xilinx-microblaze
-        > cmake -DCMAKE_TOOLCHAIN_FILE=../../../cmake/toolchain-xilinx-microblaze-gnu.cmake ../.. -DCMAKE_BUILD_TYPE=Release -DCFG_COMPILE_LIB_[LIB_NAME]=ON -DCFG_COMPILE_LIB_[LIB_NAME]_LIB_DIR=[PATH_TO_HW_LIB]
+        > cmake -GUnix\ Makefiles -DCMAKE_TOOLCHAIN_FILE=../../../cmake/toolchain-xilinx-microblaze-gnu.cmake ../.. -DCMAKE_BUILD_TYPE=Release -DCFG_COMPILE_LIB_[LIB_NAME]=ON
         > make all
         > make install
 
-  This will create the `[LIB_NAME]` stack library for the hardware library in `[PATH_TO_HW_LIB]`.
-  Multiple stack libraries can be built together by passing the define pairs (`CFG_COMPILE_LIB_[LIB_NAME]`
-  and `CFG_COMPILE_LIB_[LIB_NAME]_LIB_DIR`) for each stack library to CMake.
-  Refer to \ref sect_build_stack_options_noos_microblaze for details!
+  This will create the `[LIB_NAME]` stack library (release) for the hardware library
 
 The default library installation path is:
 `<openPOWERLINK_dir>/stack/lib/generic/microblaze/<BOARD_NAME>/<DEMO_NAME>`
@@ -289,6 +283,13 @@ the configuration options on the command line (-DCFG_XXX=XXX) or
 - **CFG_COMPILE_LIB_MNAPP_ZYNQINTF**
 
   Compile openPOWERLINK MN application library for Zynq platform, that contains the
+  interface to a Linux kernel platform interface driver. It is used along with the Linux
+  kernel platform interface driver for status/control and data exchange with the kernel
+  stack which runs on Zynq Microblaze as a baremetal application.
+
+- **CFG_COMPILE_LIB_CNAPP_ZYNQINTF**
+
+  Compile openPOWERLINK CN application library for Zynq platform, that contains the
   interface to a Linux kernel platform interface driver. It is used along with the Linux
   kernel platform interface driver for status/control and data exchange with the kernel
   stack which runs on Zynq Microblaze as a baremetal application.

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@ openPOWERLINK {#mainpage}
 
 ## openPOWERLINK - An Open Source POWERLINK protocol stack
 
-<a href="https://travis-ci.org/OpenAutomationTechnologies/openPOWERLINK_V2"><img src="https://secure.travis-ci.org/OpenAutomationTechnologies/openPOWERLINK_V2.png?branch=master"/></a>
+<img style="float:left;" src="https://secure.travis-ci.org/OpenAutomationTechnologies/openPOWERLINK_V2.png?branch=master"/><br/>
 
 Ethernet POWERLINK is a Real-Time Ethernet field bus system. It is
 based on the Fast Ethernet Standard IEEE 802.3.


### PR DESCRIPTION
 - Fix compilation warnings
 - Add Zynq Hybrid CN build steps in the generic .md files

**Known issue:**
2 warnings are reported as DOT_GRAPH_MAX_NODES is 50. 

1. Included by graph for 'target.h' not generated, too many nodes. Consider increasing DOT_GRAPH_MAX_NODES.
2. Included by graph for 'oplkinc.h' not generated, too many nodes. Consider increasing DOT_GRAPH_MAX_NODES.