### PR TITLE
[FIX] Fix Windows NDIS & PCIe basic run issue

### DIFF
--- a/stack/include/common/pdo.h
+++ b/stack/include/common/pdo.h
@@ -9,6 +9,7 @@
 /*------------------------------------------------------------------------------
 Copyright (c) 2012, SYSTEC electronic GmbH
 Copyright (c) 2017, B&R Industrial Automation GmbH
+Copyright (c) 2018, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -93,10 +94,9 @@ PDO channel information between the user and the kernel layer.
 */
 typedef struct
 {
-    UINT8               channelId;              ///< ID of the PDO channel
-    BOOL                fTx;                    ///< Flag determines the direction. TRUE = TPDO, FALSE = RPDO
-    UINT8               aPadding[2];            ///< Padding for 32 bit alignment
-    tPdoChannel         pdoChannel;             ///< The PDO channel itself
+    UINT8                channelId;              ///< ID of the PDO channel
+    UINT8                fTx;                    ///< Flag determines the direction. TRUE = TPDO, FALSE = RPDO
+    tPdoChannel          pdoChannel;             ///< The PDO channel itself
 } tPdoChannelConf;
 
 /**

--- a/stack/include/kernel/dllkfilter.h
+++ b/stack/include/kernel/dllkfilter.h
@@ -12,6 +12,7 @@ can only be used for MACs which have a frame filter.
 /*------------------------------------------------------------------------------
 Copyright (c) 2013, SYSTEC electronic GmbH
 Copyright (c) 2016, B&R Industrial Automation GmbH
+Copyright (c) 2018, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -92,7 +93,7 @@ extern "C"
 
 void dllkfilter_setupFilters(void);
 void dllkfilter_setupPresFilter(tEdrvFilter* pFilter_p, BOOL fEnable_p);
-void dllkfilter_setupPreqFilter(tEdrvFilter* pFilter_p, UINT8 nodeId_p,
+void dllkfilter_setupPreqFilter(tEdrvFilter* pFilter_p, UINT nodeId_p,
                                 tEdrvTxBuffer* pBuffer_p,
                                 const UINT8* pMacAdrs_p);
 

--- a/stack/include/kernel/pdoklut.h
+++ b/stack/include/kernel/pdoklut.h
@@ -9,6 +9,7 @@ This file contains the definitions needed by the PDO lookup table module.
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2017, B&R Industrial Automation GmbH
+Copyright (c) 2018, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -77,7 +78,7 @@ extern "C"
 void       pdoklut_clear(tPdoklutEntry* pLut_p, size_t numEntries_p);
 tOplkError pdoklut_addChannel(tPdoklutEntry* pLut_p,
                               const tPdoChannel* pPdoChannel_p,
-                              UINT8 channelId_p);
+                              UINT channelId_p);
 UINT8      pdoklut_getChannel(const tPdoklutEntry* pLut_p,
                               UINT8 index_p,
                               UINT8 nodeId_p)

--- a/stack/include/oplk/dll.h
+++ b/stack/include/oplk/dll.h
@@ -11,6 +11,7 @@ This file contains the definitions for the DLL module.
 /*------------------------------------------------------------------------------
 Copyright (c) 2013, SYSTEC electronic GmbH
 Copyright (c) 2016, B&R Industrial Automation GmbH
+Copyright (c) 2018, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -179,8 +180,9 @@ This struct provides information about the unreceived Asnd frame.
 */
 typedef struct
 {
-    UINT8   nodeId;         ///< Source node ID of missed Asnd frame
-    UINT8   serviceId;      ///< Service ID of missed Asnd frame
+    UINT8    nodeId;         ///< Source node ID of missed Asnd frame
+    UINT8    serviceId;      ///< Service ID of missed Asnd frame
+    UINT8    padding[2];     ///< Padding variable
 } tDllAsndNotRx;
 
 /**
@@ -191,28 +193,26 @@ the data link layer (DLL).
 */
 typedef struct
 {
-    UINT32              sizeOfStruct;               ///< Size of the structure
+    UINT                sizeOfStruct;               ///< Size of the structure
     BOOL                fAsyncOnly;                 ///< Async only node, does not need to register PRes-Frame
-    UINT8               nodeId;                     ///< Local node ID
-    UINT8               padding0[3];                ///< Padding to 32 bit boundary
+    UINT                nodeId;                     ///< Local node ID
     UINT32              featureFlags;               ///< 0x1F82: NMT_FeatureFlags_U32
     UINT32              cycleLen;                   ///< Cycle Length (0x1006: NMT_CycleLen_U32) in [us], required for error detection
-    UINT16              isochrTxMaxPayload;         ///< 0x1F98.1: IsochrTxMaxPayload_U16
-    UINT16              isochrRxMaxPayload;         ///< 0x1F98.2: IsochrRxMaxPayload_U16
+    UINT                isochrTxMaxPayload;         ///< 0x1F98.1: IsochrTxMaxPayload_U16
+    UINT                isochrRxMaxPayload;         ///< 0x1F98.2: IsochrRxMaxPayload_U16
     UINT32              presMaxLatency;             ///< 0x1F98.3: PResMaxLatency_U32 in [ns], only required for IdentRes
-    UINT16              preqActPayloadLimit;        ///< 0x1F98.4: PReqActPayloadLimit_U16, required for initialization (+24 bytes)
-    UINT16              presActPayloadLimit;        ///< 0x1F98.5: PResActPayloadLimit_U16, required for initialization of Pres frame (+24 bytes)
+    UINT                preqActPayloadLimit;        ///< 0x1F98.4: PReqActPayloadLimit_U16, required for initialization (+24 bytes)
+    UINT                presActPayloadLimit;        ///< 0x1F98.5: PResActPayloadLimit_U16, required for initialization of Pres frame (+24 bytes)
     UINT32              asndMaxLatency;             ///< 0x1F98.6: ASndMaxLatency_U32 in [ns], only required for IdentRes
-    UINT8               multipleCycleCnt;           ///< 0x1F98.7: MultiplCycleCnt_U8, required for error detection
-    UINT8               padding1[3];                ///< Padding to 32 bit boundary
-    UINT16              asyncMtu;                   ///< 0x1F98.8: AsyncMTU_U16, required to set up max frame size
-    UINT16              prescaler;                  ///< 0x1F98.9: Prescaler_U16, configures the toggle rate of the SoC PS flag
+    UINT                multipleCycleCnt;           ///< 0x1F98.7: MultiplCycleCnt_U8, required for error detection
+    UINT                asyncMtu;                   ///< 0x1F98.8: AsyncMTU_U16, required to set up max frame size
+    UINT                prescaler;                  ///< 0x1F98.9: Prescaler_U16, configures the toggle rate of the SoC PS flag
     // $$$ Multiplexed Slot
     UINT32              lossOfFrameTolerance;       ///< 0x1C14: DLL_LossOfFrameTolerance_U32 in [ns]
     UINT32              waitSocPreq;                ///< 0x1F8A.1: WaitSoCPReq_U32 in [ns]
     UINT32              asyncSlotTimeout;           ///< 0x1F8A.2: AsyncSlotTimeout_U32 in [ns]
     UINT32              syncResLatency;             ///< Constant response latency for SyncRes in [ns]
-    UINT32              syncNodeId;                 ///< Synchronization trigger (AppCbSync, cycle preparation) after PRes from CN with this node-ID (0 = SoC, 255 = SoA)
+    UINT                syncNodeId;                 ///< Synchronization trigger (AppCbSync, cycle preparation) after PRes from CN with this node-ID (0 = SoC, 255 = SoA)
     BOOL                fSyncOnPrcNode;             ///< TRUE: CN is PRes chained; FALSE: conventional CN (PReq/PRes)
 #if defined(CONFIG_INCLUDE_NMT_RMN)
     UINT32              switchOverTimeMn;           ///< Switch over time when CS_OPERATIONAL in [us]
@@ -230,7 +230,7 @@ node on the network.
 */
 typedef struct
 {
-    UINT32              sizeOfStruct;                   ///< Size of the structure
+    UINT                sizeOfStruct;                   ///< Size of the structure
     UINT32              deviceType;                     ///< NMT_DeviceType_U32
     UINT32              vendorId;                       ///< NMT_IdentityObject_REC.VendorId_U32
     UINT32              productCode;                    ///< NMT_IdentityObject_REC.ProductCode_U32

--- a/stack/include/oplk/targetdefs/windows.h
+++ b/stack/include/oplk/targetdefs/windows.h
@@ -76,12 +76,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef FALSE
 #undef FALSE
 #endif
-#define FALSE 0
+#define FALSE 0x00
 
 #ifdef TRUE
 #undef TRUE
 #endif
-#define TRUE 1
+#define TRUE 0xFF
 
 #ifdef _CONSOLE // use standard printf in console applications
 #define PRINTF(...)             printf(__VA_ARGS__)

--- a/stack/include/oplk/targetdefs/winkernel.h
+++ b/stack/include/oplk/targetdefs/winkernel.h
@@ -71,12 +71,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef FALSE
 #undef FALSE
 #endif
-#define FALSE 0
+#define FALSE 0x00
 
 #ifdef TRUE
 #undef TRUE
 #endif
-#define TRUE 1
+#define TRUE 0xFF
 
 #define PRINTF(...)    DbgPrint(__VA_ARGS__)
 

--- a/stack/src/kernel/dll/dllk.c
+++ b/stack/src/kernel/dll/dllk.c
@@ -12,7 +12,7 @@ This file contains the implementation of the DLL kernel module.
 /*------------------------------------------------------------------------------
 Copyright (c) 2015, SYSTEC electronic GmbH
 Copyright (c) 2017, B&R Industrial Automation GmbH
-Copyright (c) 2017, Kalycito Infotech Private Limited
+Copyright (c) 2018, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -547,16 +547,24 @@ tOplkError dllk_configNode(const tDllNodeInfo* pNodeInfo_p)
 
     // copy node configuration
     if (pNodeInfo_p->presPayloadLimit > dllkInstance_g.dllConfigParam.isochrRxMaxPayload)
-        pIntNodeInfo->presPayloadLimit = dllkInstance_g.dllConfigParam.isochrRxMaxPayload;
+    {
+        pIntNodeInfo->presPayloadLimit = (UINT16)dllkInstance_g.dllConfigParam.isochrRxMaxPayload;
+    }
     else
+    {
         pIntNodeInfo->presPayloadLimit = pNodeInfo_p->presPayloadLimit;
+    }
 
 #if defined(CONFIG_INCLUDE_NMT_MN)
     pIntNodeInfo->presTimeoutNs = pNodeInfo_p->presTimeoutNs;
     if (pNodeInfo_p->preqPayloadLimit > dllkInstance_g.dllConfigParam.isochrTxMaxPayload)
-        pIntNodeInfo->preqPayloadLimit = dllkInstance_g.dllConfigParam.isochrTxMaxPayload;
+    {
+        pIntNodeInfo->preqPayloadLimit = (UINT16)dllkInstance_g.dllConfigParam.isochrTxMaxPayload;
+    }
     else
+    {
         pIntNodeInfo->preqPayloadLimit = pNodeInfo_p->preqPayloadLimit;
+    }
 
     // initialize elements of internal node info structure
     pIntNodeInfo->soaFlag1 = PLK_FRAME_FLAG1_ER;

--- a/stack/src/kernel/dll/dllkfilter.c
+++ b/stack/src/kernel/dll/dllkfilter.c
@@ -12,6 +12,7 @@ This file contains the functions to setup the edrv filter structures.
 /*------------------------------------------------------------------------------
 Copyright (c) 2013, SYSTEC electronic GmbH
 Copyright (c) 2016, B&R Industrial Automation GmbH
+Copyright (c) 2018, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -137,13 +138,13 @@ void dllkfilter_setupFilters(void)
     setupSocFilter(&dllkInstance_g.aFilter[DLLK_FILTER_SOC]);
     setupSoaFilter(&dllkInstance_g.aFilter[DLLK_FILTER_SOA]);
     setupSoaIdentReqFilter(&dllkInstance_g.aFilter[DLLK_FILTER_SOA_IDREQ],
-                           dllkInstance_g.dllConfigParam.nodeId,
+                           (UINT8)dllkInstance_g.dllConfigParam.nodeId,
                            &dllkInstance_g.pTxBuffer[DLLK_TXFRAME_IDENTRES]);
     setupSoaStatusReqFilter(&dllkInstance_g.aFilter[DLLK_FILTER_SOA_STATREQ],
-                            dllkInstance_g.dllConfigParam.nodeId,
+                            (UINT8)dllkInstance_g.dllConfigParam.nodeId,
                             &dllkInstance_g.pTxBuffer[DLLK_TXFRAME_STATUSRES]);
     setupSoaNmtReqFilter(&dllkInstance_g.aFilter[DLLK_FILTER_SOA_NMTREQ],
-                         dllkInstance_g.dllConfigParam.nodeId,
+                         (UINT8)dllkInstance_g.dllConfigParam.nodeId,
                          &dllkInstance_g.pTxBuffer[DLLK_TXFRAME_NMTREQ]);
 #if (CONFIG_DLL_PRES_CHAINING_CN != FALSE)
     setupSoaSyncReqFilter(&dllkInstance_g.aFilter[DLLK_FILTER_SOA_SYNCREQ],
@@ -151,7 +152,7 @@ void dllkfilter_setupFilters(void)
                           &dllkInstance_g.pTxBuffer[DLLK_TXFRAME_SYNCRES]);
 #endif
     setupSoaUnspecReqFilter(&dllkInstance_g.aFilter[DLLK_FILTER_SOA_NONPLK],
-                            dllkInstance_g.dllConfigParam.nodeId,
+                            (UINT8)dllkInstance_g.dllConfigParam.nodeId,
                             &dllkInstance_g.pTxBuffer[DLLK_TXFRAME_NONPLK]);
 #if defined(CONFIG_INCLUDE_VETH)
     setupVethUnicast(&dllkInstance_g.aFilter[DLLK_FILTER_VETH_UNICAST],
@@ -200,7 +201,7 @@ The function sets up an PReq filter in the Edrv filter structure.
 */
 //------------------------------------------------------------------------------
 void dllkfilter_setupPreqFilter(tEdrvFilter* pFilter_p,
-                                UINT8 nodeId_p,
+                                UINT nodeId_p,
                                 tEdrvTxBuffer* pBuffer_p,
                                 const UINT8* pMacAdrs_p)
 {
@@ -215,7 +216,7 @@ void dllkfilter_setupPreqFilter(tEdrvFilter* pFilter_p,
     ami_setUint16Be(&pFilter_p->aFilterMask[12], 0xFFFF);
     ami_setUint8Be(&pFilter_p->aFilterValue[14], kMsgTypePreq);
     ami_setUint8Be(&pFilter_p->aFilterMask[14], 0xFF);
-    ami_setUint8Be(&pFilter_p->aFilterValue[15], nodeId_p);
+    ami_setUint8Be(&pFilter_p->aFilterValue[15], (UINT8)nodeId_p);
     ami_setUint8Be(&pFilter_p->aFilterMask[15], 0xFF);
     ami_setUint8Be(&pFilter_p->aFilterValue[16], C_ADR_MN_DEF_NODE_ID);
     ami_setUint8Be(&pFilter_p->aFilterMask[16], 0xFF);

--- a/stack/src/kernel/dll/dllkframe.c
+++ b/stack/src/kernel/dll/dllkframe.c
@@ -12,6 +12,7 @@ This file contains the frame processing functions of the kernel DLL module.
 /*------------------------------------------------------------------------------
 Copyright (c) 2018, B&R Industrial Automation GmbH
 Copyright (c) 2015, SYSTEC electronic GmbH
+Copyright (c) 2018, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -700,7 +701,7 @@ tOplkError dllkframe_checkFrame(tPlkFrame* pFrame_p, size_t frameSize_p)
         if (etherType == C_DLL_ETHERTYPE_EPL)
         {
             // source node ID
-            ami_setUint8Le(&pFrame_p->srcNodeId, dllkInstance_g.dllConfigParam.nodeId);
+            ami_setUint8Le(&pFrame_p->srcNodeId, (UINT8)dllkInstance_g.dllConfigParam.nodeId);
 
             // check message type
             msgType = (tMsgType)ami_getUint8Le(&pFrame_p->messageType);
@@ -879,7 +880,7 @@ tOplkError dllkframe_createTxFrame(UINT* pHandle_p,
         if (msgType_p != kMsgTypeNonPowerlink)
         {   // fill out Frame only if it is a POWERLINK frame
             ami_setUint16Be(&pTxFrame->etherType, C_DLL_ETHERTYPE_EPL);
-            ami_setUint8Le(&pTxFrame->srcNodeId, dllkInstance_g.dllConfigParam.nodeId);
+            ami_setUint8Le(&pTxFrame->srcNodeId, (UINT8)dllkInstance_g.dllConfigParam.nodeId);
             OPLK_MEMCPY(&pTxFrame->aSrcMac[0], edrv_getMacAddr(), 6);
 
             switch (msgType_p)
@@ -896,11 +897,11 @@ tOplkError dllkframe_createTxFrame(UINT* pHandle_p,
                             ami_setUint32Le(&pTxFrame->data.asnd.payload.identResponse.featureFlagsLe,
                                             dllkInstance_g.dllConfigParam.featureFlags);
                             ami_setUint16Le(&pTxFrame->data.asnd.payload.identResponse.mtuLe,
-                                            dllkInstance_g.dllConfigParam.asyncMtu);
+                                            (UINT16)dllkInstance_g.dllConfigParam.asyncMtu);
                             ami_setUint16Le(&pTxFrame->data.asnd.payload.identResponse.pollInSizeLe,
-                                            dllkInstance_g.dllConfigParam.preqActPayloadLimit);
+                                            (UINT16)dllkInstance_g.dllConfigParam.preqActPayloadLimit);
                             ami_setUint16Le(&pTxFrame->data.asnd.payload.identResponse.pollOutSizeLe,
-                                            dllkInstance_g.dllConfigParam.presActPayloadLimit);
+                                            (UINT16)dllkInstance_g.dllConfigParam.presActPayloadLimit);
                             ami_setUint32Le(&pTxFrame->data.asnd.payload.identResponse.responseTimeLe,
                                             dllkInstance_g.dllConfigParam.presMaxLatency);
                             ami_setUint32Le(&pTxFrame->data.asnd.payload.identResponse.deviceTypeLe,

--- a/stack/src/kernel/pdo/pdoklut.c
+++ b/stack/src/kernel/pdo/pdoklut.c
@@ -12,6 +12,7 @@ used for fast searching of PDO channels for a specific node.
 
 /*------------------------------------------------------------------------------
 Copyright (c) 2017, B&R Industrial Automation GmbH
+Copyright (c) 2018, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -132,11 +133,11 @@ This function adds a new PDO channel to the lookup table.
 //------------------------------------------------------------------------------
 tOplkError pdoklut_addChannel(tPdoklutEntry* pLut_p,
                               const tPdoChannel* pPdoChannel_p,
-                              UINT8 channelId_p)
+                              UINT channelId_p)
 {
     tOplkError      ret = kErrorIllegalInstance;
     int             i;
-    UINT8           nodeId;
+    UINT            nodeId;
 
     // Check parameter validity
     ASSERT(pLut_p != NULL);

--- a/stack/src/user/pdo/pdou.c
+++ b/stack/src/user/pdo/pdou.c
@@ -12,6 +12,7 @@ This file contains the implementation of the user PDO module.
 /*------------------------------------------------------------------------------
 Copyright (c) 2012, SYSTEC electronic GmbH
 Copyright (c) 2017, B&R Industrial Automation GmbH
+Copyright (c) 2018, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -141,8 +142,8 @@ The following structure defines the instance variable of the user PDO module.
 */
 typedef struct
 {
-    UINT8                   aPdoIdToChannelIdRx[(PDOU_PDO_ID_MASK + 1)]; ///< RXPDO to channel ID conversion table
-    UINT8                   aPdoIdToChannelIdTx[(PDOU_PDO_ID_MASK + 1)]; ///< TXPDO to channel ID conversion table
+    BYTE                    aPdoIdToChannelIdRx[(PDOU_PDO_ID_MASK + 1)]; ///< RXPDO to channel ID conversion table
+    BYTE                    aPdoIdToChannelIdTx[(PDOU_PDO_ID_MASK + 1)]; ///< TXPDO to channel ID conversion table
     tPdoChannelSetup        pdoChannels;                ///< PDO channel setup
     tPdoMappObject*         paRxObject;                 ///< Pointer to RX channel objects
     tPdoMappObject*         paTxObject;                 ///< Pointer to TX channel objects
@@ -166,27 +167,27 @@ static tOplkError callPdoChangeCb(BOOL fActivated_p,
                                   UINT mappParamIndex_p,
                                   UINT8 mappObjectCount_p,
                                   BOOL fTx_p);
-static tOplkError setupRxPdoChannelTables(UINT8 abChannelIdToPdoIdRx_p[D_PDO_RPDOChannels_U16],
+static tOplkError setupRxPdoChannelTables(BYTE abChannelIdToPdoIdRx_p[D_PDO_RPDOChannels_U16],
                                           UINT* pCountChannelIdRx_p);
-static tOplkError setupTxPdoChannelTables(UINT8 abChannelIdToPdoIdTx_p[D_PDO_TPDOChannels_U16],
+static tOplkError setupTxPdoChannelTables(BYTE abChannelIdToPdoIdTx_p[D_PDO_TPDOChannels_U16],
                                           UINT* pCountChannelIdTx_p);
 static tOplkError allocatePdoChannels(const tPdoAllocationParam* pAllocationParam_p);
 static tOplkError freePdoChannels(void);
 static tOplkError configureAllPdos(void);
 static tOplkError checkAndConfigurePdos(UINT16 mappParamIndex_p,
                                         UINT channelCount_p,
-                                        const UINT8* pChannelToPdoTable_p,
+                                        const BYTE* pChannelToPdoTable_p,
                                         UINT32* pAbortCode_p);
 static tOplkError checkAndConfigurePdo(UINT16 mappParamIndex_p,
                                        UINT8 mappObjectCount_p,
                                        UINT32* pAbortCode_p);
 static tOplkError checkPdoValidity(UINT mappParamIndex_p, UINT32* pAbortCode_p);
-static void decodeObjectMapping(UINT64 objectMapping_p,
+static void decodeObjectMapping(QWORD objectMapping_p,
                                 UINT* pIndex_p,
                                 UINT* pSubIndex_p,
                                 UINT* pBitOffset_p,
                                 UINT* pBitSize_p);
-static tOplkError checkAndSetObjectMapping(UINT64 objectMapping_p,
+static tOplkError checkAndSetObjectMapping(QWORD objectMapping_p,
                                            tObdAccess neededAccessType_p,
                                            tPdoMappObject* pMappObject_p,
                                            UINT32* pAbortCode_p,
@@ -194,14 +195,14 @@ static tOplkError checkAndSetObjectMapping(UINT64 objectMapping_p,
                                            UINT* pNextObjectOffset_p);
 static tOplkError setupMappingObjects(tPdoMappObject* pMappObject_p,
                                       UINT mappParamIndex_p,
-                                      UINT8 mappObjectCount_p,
+                                      BYTE mappObjectCount_p,
                                       UINT16 maxPdoSize_p,
                                       UINT32* pAbortCode_p,
                                       UINT16* pOffset_p,
                                       UINT16* pNextChannelOffset_p,
                                       UINT16* pCount_p);
 static tOplkError configurePdoChannel(const tPdoChannelConf* pChannelConf_p);
-static tOplkError getMaxPdoSize(UINT8 nodeId_p,
+static tOplkError getMaxPdoSize(BYTE nodeId_p,
                                 BOOL fTxPdo_p,
                                 UINT16* pMaxPdoSize_p,
                                 UINT32* pAbortCode_p);
@@ -209,10 +210,10 @@ static tOplkError getPdoChannelId(UINT pdoId_p, BOOL fTxPdo_p, UINT8* pChannelId
 static size_t calcPdoMemSize(const tPdoChannelSetup* pPdoChannels_p,
                              size_t* pRxPdoMemSize_p,
                              size_t* pTxPdoMemSize_p);
-static tOplkError copyVarToPdo(void* pPayload_p,
+static tOplkError copyVarToPdo(BYTE* pPayload_p,
                                const tPdoMappObject* pMappObject_p,
                                UINT16 offsetInFrame_p);
-static tOplkError copyVarFromPdo(const void* pPayload_p,
+static tOplkError copyVarFromPdo(const BYTE* pPayload_p,
                                  const tPdoMappObject* pMappObject_p,
                                  UINT16 offsetInFrame_p);
 
@@ -389,7 +390,7 @@ tOplkError pdou_cbObdAccess(tObdCbParam* pParam_p)
 {
     tOplkError  ret = kErrorOk;
     UINT        indexType;
-    UINT8       mappObjectCount;
+    BYTE        mappObjectCount;
     UINT        offset;
     UINT        nextObjectOffset;
     tObdAccess  neededAccessType;
@@ -435,7 +436,7 @@ tOplkError pdou_cbObdAccess(tObdCbParam* pParam_p)
     if (pParam_p->subIndex == 0)
     {   // object mapping count accessed
         // PDO is enabled or disabled
-        mappObjectCount = *((UINT8*)pParam_p->pArg);
+        mappObjectCount = *((BYTE*)pParam_p->pArg);
         ret = checkAndConfigurePdo(pParam_p->index, mappObjectCount,
                                    &pParam_p->abortCode);
         if (ret != kErrorOk)
@@ -445,7 +446,7 @@ tOplkError pdou_cbObdAccess(tObdCbParam* pParam_p)
     {
         // ObjectMapping
         tPdoMappObject  mappObject;     // temporary object for check
-        UINT64          objectMapping;
+        QWORD           objectMapping;
 
         ret = checkPdoValidity(pParam_p->index, &pParam_p->abortCode);
         if (ret != kErrorOk)
@@ -454,7 +455,7 @@ tOplkError pdou_cbObdAccess(tObdCbParam* pParam_p)
         }
 
         // check existence of object and validity of object length
-        objectMapping = *((UINT64*)pParam_p->pArg);
+        objectMapping = *((QWORD*)pParam_p->pArg);
         ret = checkAndSetObjectMapping(objectMapping,
                                        neededAccessType,
                                        &mappObject,
@@ -483,8 +484,8 @@ tOplkError pdou_copyRxPdoToPi(void)
     UINT                    mappObjectCount;
     const tPdoChannel*      pPdoChannel;
     const tPdoMappObject*   pMappObject;
-    UINT8                   channelId;
-    void*                   pPdo;
+    UINT                    channelId;
+    void*                  pPdo;
 
     if (target_lockMutex(pdouInstance_g.lockMutex) != kErrorOk)
         return kErrorIllegalInstance;
@@ -556,8 +557,8 @@ tOplkError pdou_copyTxPdoFromPi(void)
     UINT                    mappObjectCount;
     const tPdoChannel*      pPdoChannel;
     const tPdoMappObject*   pMappObject;
-    UINT8                   channelId;
-    void*                   pPdo;
+    UINT                    channelId;
+    BYTE*                   pPdo;
 
     //TRACE_FUNC_ENTRY;
     if (target_lockMutex(pdouInstance_g.lockMutex) != kErrorOk)
@@ -710,12 +711,12 @@ memory to store the mapping information.
 **/
 //------------------------------------------------------------------------------
 static tOplkError setupRxPdoChannelTables(
-                      UINT8 abChannelIdToPdoIdRx_p[D_PDO_RPDOChannels_U16],
+                      BYTE abChannelIdToPdoIdRx_p[D_PDO_RPDOChannels_U16],
                       UINT* pCountChannelIdRx_p)
 {
     tOplkError  ret = kErrorOk;
     tObdSize    obdSize;
-    UINT8       nodeId;
+    BYTE        nodeId;
     UINT        pdoId;
     UINT        commParamIndex;
     UINT        channelCount = 0;
@@ -745,8 +746,8 @@ static tOplkError setupRxPdoChannelTables(
                 if (channelCount > D_PDO_RPDOChannels_U16)
                     return kErrorPdoTooManyPdos;
 
-                pdouInstance_g.aPdoIdToChannelIdRx[pdoId] = (UINT8)channelCount - 1;
-                abChannelIdToPdoIdRx_p[channelCount - 1] = (UINT8)pdoId;
+                pdouInstance_g.aPdoIdToChannelIdRx[pdoId] = (BYTE)channelCount - 1;
+                abChannelIdToPdoIdRx_p[channelCount - 1] = (BYTE)pdoId;
                 break;
 
             default:
@@ -779,12 +780,12 @@ memory to store the mapping information.
 **/
 //------------------------------------------------------------------------------
 static tOplkError setupTxPdoChannelTables(
-                      UINT8 abChannelIdToPdoIdTx_p[D_PDO_TPDOChannels_U16],
+                      BYTE abChannelIdToPdoIdTx_p[D_PDO_TPDOChannels_U16],
                       UINT* pCountChannelIdTx_p)
 {
     tOplkError  ret = kErrorOk;
     tObdSize    obdSize;
-    UINT8       nodeId;
+    BYTE        bNodeId;
     UINT        pdoId;
     UINT        commParamIndex;
     UINT        channelCount = 0;
@@ -800,9 +801,9 @@ static tOplkError setupTxPdoChannelTables(
          pdoId < PDOU_MAX_PDO_OBJECTS;
          pdoId++, commParamIndex++)
     {
-        obdSize = (tObdSize)sizeof(nodeId);
+        obdSize = (tObdSize)sizeof(bNodeId);
         // read node ID from OD (ID:0x18XX Sub:1)
-        ret = obdu_readEntry(commParamIndex, 0x01, &nodeId, &obdSize);
+        ret = obdu_readEntry(commParamIndex, 0x01, &bNodeId, &obdSize);
         switch (ret)
         {
             case kErrorObdIndexNotExist:
@@ -816,8 +817,8 @@ static tOplkError setupTxPdoChannelTables(
                 if (channelCount > D_PDO_TPDOChannels_U16)
                     return kErrorPdoTooManyTxPdos;
 
-                pdouInstance_g.aPdoIdToChannelIdTx[pdoId] = (UINT8)channelCount - 1;
-                abChannelIdToPdoIdTx_p[channelCount - 1] = (UINT8)pdoId;
+                pdouInstance_g.aPdoIdToChannelIdTx[pdoId] = (BYTE)channelCount - 1;
+                abChannelIdToPdoIdTx_p[channelCount - 1] = (BYTE)pdoId;
                 break;
 
             default:
@@ -993,8 +994,8 @@ The function configures the whole PDO mapping information in the pdok module.
 static tOplkError configureAllPdos(void)
 {
     tOplkError          ret = kErrorOk;
-    UINT8               aChannelIdToPdoIdRx[D_PDO_RPDOChannels_U16];
-    UINT8               aChannelIdToPdoIdTx[D_PDO_TPDOChannels_U16];
+    BYTE                aChannelIdToPdoIdRx[D_PDO_RPDOChannels_U16];
+    BYTE                aChannelIdToPdoIdTx[D_PDO_TPDOChannels_U16];
     tPdoAllocationParam allocParam;
     UINT32              abortCode = 0;
     size_t              txPdoMemSize;
@@ -1063,13 +1064,13 @@ The functions checks and configures all PDOs for a single direction.
 //------------------------------------------------------------------------------
 static tOplkError checkAndConfigurePdos(UINT16 mappParamIndex_p,
                                         UINT channelCount_p,
-                                        const UINT8* pChannelToPdoTable_p,
+                                        const BYTE* pChannelToPdoTable_p,
                                         UINT32* pAbortCode_p)
 {
     tOplkError  ret = kErrorOk;
     UINT        index;
     tObdSize    obdSize;
-    UINT8       mappObjectCount;
+    BYTE        mappObjectCount;
     UINT        mappParamIndex;
 
     for (index = 0; index < channelCount_p; index++)
@@ -1112,8 +1113,8 @@ static tOplkError checkAndConfigurePdo(UINT16 mappParamIndex_p,
     UINT16          pdoId;
     UINT16          commParamIndex;
     tObdSize        obdSize;
-    UINT8           nodeId;
-    UINT16          maxPdoSize;
+    BYTE            nodeId;
+    WORD            maxPdoSize;
     tPdoChannelConf pdoChannelConf;
     BOOL            fTxPdo;
     tPdoMappObject* pMappObject;
@@ -1309,14 +1310,14 @@ read.
 \return The function returns a tOplkError error code.
 */
 //------------------------------------------------------------------------------
-static tOplkError getMaxPdoSize(UINT8 nodeId_p,
+static tOplkError getMaxPdoSize(BYTE nodeId_p,
                                 BOOL fTxPdo_p,
                                 UINT16* pMaxPdoSize_p,
                                 UINT32* pAbortCode_p)
 {
     tOplkError  ret = kErrorOk;
     tObdSize    obdSize;
-    UINT16      maxPdoSize;
+    WORD        maxPdoSize;
     UINT        payloadLimitIndex;
     UINT        payloadLimitSubIndex;
     UINT8       subIndexCount;
@@ -1405,8 +1406,8 @@ The function converts RPDO-ID (i.e. lower part of object index) to channel IDs.
 \return The function returns a tOplkError error code.
 **/
 //------------------------------------------------------------------------------
-static tOplkError getPdoChannelId(UINT pdoId_p,
-                                  BOOL fTxPdo_p,
+static tOplkError getPdoChannelId(UINT   pdoId_p,
+                                  BOOL   fTxPdo_p,
                                   UINT8* pChannelId_p)
 {
     tOplkError  ret = kErrorOk;
@@ -1442,7 +1443,7 @@ static tOplkError checkPdoValidity(UINT mappParamIndex_p, UINT32* pAbortCode_p)
 {
     tOplkError  ret = kErrorOk;
     tObdSize    obdSize;
-    UINT8       mappObjectCount;
+    BYTE        mappObjectCount;
 
     if (pdouInstance_g.fRunning)
     {
@@ -1487,7 +1488,7 @@ static tOplkError checkPdoValidity(UINT mappParamIndex_p, UINT32* pAbortCode_p)
 \return The function returns a tOplkError error code.
 */
 //------------------------------------------------------------------------------
-static tOplkError checkAndSetObjectMapping(UINT64 objectMapping_p,
+static tOplkError checkAndSetObjectMapping(QWORD objectMapping_p,
                                            tObdAccess neededAccessType_p,
                                            tPdoMappObject* pMappObject_p,
                                            UINT32* pAbortCode_p,
@@ -1645,7 +1646,7 @@ The function sets up the mapping objects of a PDO channel.
 //------------------------------------------------------------------------------
 static tOplkError setupMappingObjects(tPdoMappObject* pMappObject_p,
                                       UINT mappParamIndex_p,
-                                      UINT8 mappObjectCount_p,
+                                      BYTE mappObjectCount_p,
                                       UINT16 maxPdoSize_p,
                                       UINT32* pAbortCode_p,
                                       UINT16* pOffset_p,
@@ -1654,9 +1655,9 @@ static tOplkError setupMappingObjects(tPdoMappObject* pMappObject_p,
 {
     tOplkError  ret = kErrorOk;
     tObdSize    obdSize;
-    UINT64      objectMapping;
+    QWORD       objectMapping;
     UINT        count = 0;
-    UINT8       mappSubindex;
+    BYTE        mappSubindex;
     UINT        offset;
     UINT        nextObjectOffset;
     UINT16      calcNextObjectOffset = 0;
@@ -1733,7 +1734,7 @@ bit offset and bit size.
 \param[out]     pBitSize_p          Pointer to store bit size.
 */
 //------------------------------------------------------------------------------
-static void decodeObjectMapping(UINT64 objectMapping_p,
+static void decodeObjectMapping(QWORD objectMapping_p,
                                 UINT* pIndex_p,
                                 UINT* pSubIndex_p,
                                 UINT* pBitOffset_p,
@@ -1759,7 +1760,7 @@ payload.
 \return The function returns a tOplkError error code.
 **/
 //------------------------------------------------------------------------------
-static tOplkError copyVarToPdo(void* pPayload_p,
+static tOplkError copyVarToPdo(BYTE* pPayload_p,
                                const tPdoMappObject* pMappObject_p,
                                UINT16 offsetInFrame_p)
 {
@@ -1768,7 +1769,7 @@ static tOplkError copyVarToPdo(void* pPayload_p,
     void*       pVar;
 
     byteOffset = PDO_MAPPOBJECT_GET_BITOFFSET(pMappObject_p) >> 3;
-    pPayload_p = (UINT8*)pPayload_p + byteOffset - offsetInFrame_p;
+    pPayload_p = pPayload_p + byteOffset - offsetInFrame_p;
     pVar = PDO_MAPPOBJECT_GET_VAR(pMappObject_p);
 
     switch (PDO_MAPPOBJECT_GET_TYPE(pMappObject_p))
@@ -1860,7 +1861,7 @@ payload.
 \return The function returns a tOplkError error code.
 **/
 //------------------------------------------------------------------------------
-static tOplkError copyVarFromPdo(const void* pPayload_p,
+static tOplkError copyVarFromPdo(const BYTE* pPayload_p,
                                  const tPdoMappObject* pMappObject_p,
                                  UINT16 offsetInFrame_p)
 {
@@ -1869,7 +1870,7 @@ static tOplkError copyVarFromPdo(const void* pPayload_p,
     void*       pVar;
 
     byteOffset = PDO_MAPPOBJECT_GET_BITOFFSET(pMappObject_p) >> 3;
-    pPayload_p = (const UINT8*)pPayload_p + byteOffset - offsetInFrame_p;
+    pPayload_p = pPayload_p + byteOffset - offsetInFrame_p;
     pVar = PDO_MAPPOBJECT_GET_VAR(pMappObject_p);
 
     switch (PDO_MAPPOBJECT_GET_TYPE(pMappObject_p))
@@ -1964,7 +1965,7 @@ static size_t calcPdoMemSize(const tPdoChannelSetup* pPdoChannels_p,
                              size_t* pRxPdoMemSize_p,
                              size_t* pTxPdoMemSize_p)
 {
-    UINT8               channelId;
+    UINT                channelId;
     size_t              rxSize;
     size_t              txSize;
     const tPdoChannel*  pPdoChannel;


### PR DESCRIPTION
 - Revert data types to fixed-size type
 - Cleanup windows.h and winkernel.h with respect to basictypes.h
 - Fix compiler warnings in pdou.c

This pull request supersedes #377 and resolves #354. Comments in pull request #377 are addressed here.
Basic run test is tested in all Windows and Linux platforms and found working fine.

**Kind Note:** In file dllkframce.c file, line length is exceeding 100 characters. But this cannot be taken to a separate line. Hence vera++ errors are ignored here.