### PR TITLE
[FIX] Fix Windows NDIS and PCIe basic run issue

### DIFF
--- a/stack/include/common/pdo.h
+++ b/stack/include/common/pdo.h
@@ -9,6 +9,7 @@
 /*------------------------------------------------------------------------------
 Copyright (c) 2012, SYSTEC electronic GmbH
 Copyright (c) 2017, B&R Industrial Automation GmbH
+Copyright (c) 2018, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -94,7 +95,7 @@ PDO channel information between the user and the kernel layer.
 typedef struct
 {
     UINT8               channelId;              ///< ID of the PDO channel
-    BOOL                fTx;                    ///< Flag determines the direction. TRUE = TPDO, FALSE = RPDO
+    UINT8               fTx;                    ///< Flag determines the direction. TRUE = TPDO, FALSE = RPDO
     UINT8               aPadding[2];            ///< Padding for 32 bit alignment
     tPdoChannel         pdoChannel;             ///< The PDO channel itself
 } tPdoChannelConf;

--- a/stack/include/oplk/dll.h
+++ b/stack/include/oplk/dll.h
@@ -11,6 +11,7 @@ This file contains the definitions for the DLL module.
 /*------------------------------------------------------------------------------
 Copyright (c) 2013, SYSTEC electronic GmbH
 Copyright (c) 2016, B&R Industrial Automation GmbH
+Copyright (c) 2018, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -192,7 +193,7 @@ the data link layer (DLL).
 typedef struct
 {
     UINT32              sizeOfStruct;               ///< Size of the structure
-    BOOL                fAsyncOnly;                 ///< Async only node, does not need to register PRes-Frame
+    UINT8               fAsyncOnly;                 ///< Async only node, does not need to register PRes-Frame
     UINT8               nodeId;                     ///< Local node ID
     UINT8               padding0[3];                ///< Padding to 32 bit boundary
     UINT32              featureFlags;               ///< 0x1F82: NMT_FeatureFlags_U32
@@ -213,7 +214,7 @@ typedef struct
     UINT32              asyncSlotTimeout;           ///< 0x1F8A.2: AsyncSlotTimeout_U32 in [ns]
     UINT32              syncResLatency;             ///< Constant response latency for SyncRes in [ns]
     UINT32              syncNodeId;                 ///< Synchronization trigger (AppCbSync, cycle preparation) after PRes from CN with this node-ID (0 = SoC, 255 = SoA)
-    BOOL                fSyncOnPrcNode;             ///< TRUE: CN is PRes chained; FALSE: conventional CN (PReq/PRes)
+    UINT8               fSyncOnPrcNode;             ///< TRUE: CN is PRes chained; FALSE: conventional CN (PReq/PRes)
 #if defined(CONFIG_INCLUDE_NMT_RMN)
     UINT32              switchOverTimeMn;           ///< Switch over time when CS_OPERATIONAL in [us]
     UINT32              reducedSwitchOverTimeMn;    ///< Switch over time when CS_PREOPERATIONAL1 in [us]

--- a/stack/include/oplk/oplk.h
+++ b/stack/include/oplk/oplk.h
@@ -11,6 +11,7 @@ API.
 /*------------------------------------------------------------------------------
 Copyright (c) 2017, B&R Industrial Automation GmbH
 Copyright (c) 2013, SYSTEC electronic GmbH
+Copyright (c) 2018, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -422,20 +423,22 @@ byte order!
 typedef struct
 {
     UINT                sizeOfInitParam;            ///< This field contains the size of the initialization parameter structure.
-    BOOL                fAsyncOnly;                 ///< Determines if this node is an async-only node. If TRUE the node communicates only asynchronously.
-    UINT                nodeId;                     ///< The node ID of this node.
+    UINT8               fAsyncOnly;                 ///< Determines if this node is an async-only node. If TRUE the node communicates only asynchronously.
+    UINT8               nodeId;                     ///< The node ID of this node.
+    UINT8               padding1[3];                ///< Padding to 32 bit boundary
     UINT8               aMacAddress[6];             ///< The MAC address of this node.
     UINT32              featureFlags;               ///< The POWERLINK feature flags of this node (0x1F82: NMT_FeatureFlags_U32)
     UINT32              cycleLen;                   ///< The cycle Length (0x1006: NMT_CycleLen_U32) in [us]
-    UINT                isochrTxMaxPayload;         ///< Maximum isochronous transmit payload (0x1F98.1: IsochrTxMaxPayload_U16) Const!
-    UINT                isochrRxMaxPayload;         ///< Maximum isochronous receive payload (0x1F98.2: IsochrRxMaxPayload_U16) Const!
+    UINT16              isochrTxMaxPayload;         ///< Maximum isochronous transmit payload (0x1F98.1: IsochrTxMaxPayload_U16) Const!
+    UINT16              isochrRxMaxPayload;         ///< Maximum isochronous receive payload (0x1F98.2: IsochrRxMaxPayload_U16) Const!
     UINT32              presMaxLatency;             ///< Maximum PRes latency in ns (0x1F98.3: PResMaxLatency_U32) Read-only!
-    UINT                preqActPayloadLimit;        ///< Actual PReq payload limit (0x1F98.4: PReqActPayloadLimit_U16)
-    UINT                presActPayloadLimit;        ///< Actual PRes payload limit (0x1F98.5: PResActPayloadLimit_U16)
+    UINT16              preqActPayloadLimit;        ///< Actual PReq payload limit (0x1F98.4: PReqActPayloadLimit_U16)
+    UINT16              presActPayloadLimit;        ///< Actual PRes payload limit (0x1F98.5: PResActPayloadLimit_U16)
     UINT32              asndMaxLatency;             ///< Maximum ASnd latency in ns (0x1F98.6: ASndMaxLatency_U32) Const!
-    UINT                multiplCylceCnt;            ///< Multiplexed cycle count (0x1F98.7: MultiplCycleCnt_U8)
-    UINT                asyncMtu;                   ///< Asynchronous MTU (0x1F98.8: AsyncMTU_U16)
-    UINT                prescaler;                  ///< SoC prescaler (0x1F98.9: Prescaler_U16)
+    UINT8               multiplCylceCnt;            ///< Multiplexed cycle count (0x1F98.7: MultiplCycleCnt_U8)
+    UINT8               padding2[3];                ///< Padding to 32 bit boundary
+    UINT16              asyncMtu;                   ///< Asynchronous MTU (0x1F98.8: AsyncMTU_U16)
+    UINT16              prescaler;                  ///< SoC prescaler (0x1F98.9: Prescaler_U16)
     UINT32              lossOfFrameTolerance;       ///< Loss of frame tolerance in ns (0x1C14: DLL_LossOfFrameTolerance_U32)
     UINT32              waitSocPreq;                ///< Wait time for first PReq in ns (0x1F8A.1: WaitSoCPReq_U32) Only for MN!
     UINT32              asyncSlotTimeout;           ///< Asynchronous slot timeout in ns (0x1F8A.2: AsyncSlotTimeout_U32) Only for MN!
@@ -467,7 +470,7 @@ typedef struct
     tNetIfParameter     hwParam;                    ///< The network interface card parameters of the node
     UINT32              syncResLatency;             ///< Constant response latency for SyncRes in ns
     UINT                syncNodeId;                 ///< Specifies the synchronization point for the MN. The synchronization take place after a PRes from a CN with this node-ID (0 = SoC, 255 = SoA)
-    BOOL                fSyncOnPrcNode;             ///< If it is TRUE, Sync on PRes chained CN; FALSE: conventional CN (PReq/PRes)
+    UINT8               fSyncOnPrcNode;             ///< If it is TRUE, Sync on PRes chained CN; FALSE: conventional CN (PReq/PRes)
     tOplkApiSdoStack    sdoStackType;               ///< Specifies the SDO stack that should be used.
                                                     /**< It is used for switching between the standard SDO stack and alternative SDO stacks. The available SDO stacks are defined by the \ref tOplkApiSdoStack enumeration.
                                                          If the standard SDO stack is used it must be initialized with 0x00.*/

--- a/stack/include/oplk/targetdefs/windows.h
+++ b/stack/include/oplk/targetdefs/windows.h
@@ -8,7 +8,7 @@ This file contains target specific definitions for Windows.
 *******************************************************************************/
 
 /*------------------------------------------------------------------------------
-Copyright (c) 2017, Kalycito Infotech Private Limited
+Copyright (c) 2018, Kalycito Infotech Private Limited
 Copyright (c) 2016, B&R Industrial Automation GmbH
 Copyright (c) 2013, SYSTEC electronic GmbH
 All rights reserved.
@@ -76,12 +76,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef FALSE
 #undef FALSE
 #endif
-#define FALSE 0
+#define FALSE 0x00
 
 #ifdef TRUE
 #undef TRUE
 #endif
-#define TRUE 1
+#define TRUE 0xFF
 
 #ifdef _CONSOLE // use standard printf in console applications
 #define PRINTF(...)             printf(__VA_ARGS__)

--- a/stack/include/oplk/targetdefs/winkernel.h
+++ b/stack/include/oplk/targetdefs/winkernel.h
@@ -8,7 +8,7 @@ This file contains target specific definitions for Windows kernel.
 *******************************************************************************/
 
 /*------------------------------------------------------------------------------
-Copyright (c) 2015, Kalycito Infotech Private Limited
+Copyright (c) 2018, Kalycito Infotech Private Limited
 Copyright (c) 2016, B&R Industrial Automation GmbH
 All rights reserved.
 
@@ -71,12 +71,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef FALSE
 #undef FALSE
 #endif
-#define FALSE 0
+#define FALSE 0x00
 
 #ifdef TRUE
 #undef TRUE
 #endif
-#define TRUE 1
+#define TRUE 0xFF
 
 #define PRINTF(...)    DbgPrint(__VA_ARGS__)
 

--- a/stack/src/user/ctrl/ctrlu.c
+++ b/stack/src/user/ctrl/ctrlu.c
@@ -12,6 +12,7 @@ This file contains the implementation of the user stack control module.
 /*------------------------------------------------------------------------------
 Copyright (c) 2017, B&R Industrial Automation GmbH
 Copyright (c) 2015, SYSTEC electronic GmbH
+Copyright (c) 2018, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -1589,43 +1590,43 @@ static tOplkError updateObd(const tOplkApiInitParam* pInitParam_p,
     if (pInitParam_p->featureFlags != UINT_MAX)
         obdu_writeEntry(0x1F82, 0, &pInitParam_p->featureFlags, 4);
 
-    wordValue = (UINT16)pInitParam_p->isochrTxMaxPayload;
+    wordValue = pInitParam_p->isochrTxMaxPayload;
     obdu_writeEntry(0x1F98, 1, &wordValue, 2);
 
-    wordValue = (UINT16)pInitParam_p->isochrRxMaxPayload;
+    wordValue = pInitParam_p->isochrRxMaxPayload;
     obdu_writeEntry(0x1F98, 2, &wordValue, 2);
 
     obdu_writeEntry(0x1F98, 3, &pInitParam_p->presMaxLatency, 4);
 
     if (!fDisableUpdateStoredConf_p && (pInitParam_p->preqActPayloadLimit <= C_DLL_ISOCHR_MAX_PAYL))
     {
-        wordValue = (UINT16)pInitParam_p->preqActPayloadLimit;
+        wordValue = pInitParam_p->preqActPayloadLimit;
         obdu_writeEntry(0x1F98, 4, &wordValue, 2);
     }
 
     if (!fDisableUpdateStoredConf_p && (pInitParam_p->presActPayloadLimit <= C_DLL_ISOCHR_MAX_PAYL))
     {
-        wordValue = (UINT16)pInitParam_p->presActPayloadLimit;
+        wordValue = pInitParam_p->presActPayloadLimit;
         obdu_writeEntry(0x1F98, 5, &wordValue, 2);
     }
 
     obdu_writeEntry(0x1F98, 6, &pInitParam_p->asndMaxLatency, 4);
 
-    if (!fDisableUpdateStoredConf_p && (pInitParam_p->multiplCylceCnt <= 0xFF))
+    if (!fDisableUpdateStoredConf_p)
     {
-        byteValue = (UINT8)pInitParam_p->multiplCylceCnt;
+        byteValue = pInitParam_p->multiplCylceCnt;
         obdu_writeEntry(0x1F98, 7, &byteValue, 1);
     }
 
     if (!fDisableUpdateStoredConf_p && (pInitParam_p->asyncMtu <= C_DLL_MAX_ASYNC_MTU))
     {
-        wordValue = (UINT16)pInitParam_p->asyncMtu;
+        wordValue = pInitParam_p->asyncMtu;
         obdu_writeEntry(0x1F98, 8, &wordValue, 2);
     }
 
     if (!fDisableUpdateStoredConf_p && (pInitParam_p->prescaler <= 1000))
     {
-        wordValue = (UINT16)pInitParam_p->prescaler;
+        wordValue = pInitParam_p->prescaler;
         obdu_writeEntry(0x1F98, 9, &wordValue, 2);
     }
 


### PR DESCRIPTION
 - Modify data types to fixed-size type in oplk.h, dll.h and pdo.h
 - Remove typecast in ctrlu.c as the data types are modified to
   fixed-size types
 - Cleanup windows.h and winkernel.h with respect to basictypes.h

This pull request supersedes #381 and resolves #354. 

Tested basic run test in Linux edrv and all Windows platforms.