### PR TITLE
[FIX] Fix Linux PCIe compilation issue

### DIFF
--- a/drivers/linux/drv_kernelmod_pcie/CMakeLists.txt
+++ b/drivers/linux/drv_kernelmod_pcie/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 # Copyright (c) 2013, SYSTEC electronik GmbH
 # Copyright (c) 2016, B&R Industrial Automation GmbH
-# Copyright (c) 2017, Kalycito Infotech Private Limited
+# Copyright (c) 2018, Kalycito Infotech Private Limited
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -150,6 +150,7 @@ SET(MODULE_SOURCE_FILES
     ${KERNEL_SOURCE_DIR}/timesync/timesynckcal-linuxdpshm.c
     ${KERNEL_SOURCE_DIR}/veth/veth-linuxdpshm.c
     ${ARCH_SOURCE_DIR}/target-linuxkernel.c
+    ${STACK_SOURCE_DIR}/arch/linux/lock-linuxdualproc.c
     )
 
 IF(CMAKE_SYSTEM_PROCESSOR MATCHES "^(i.86|x86(_64)?)$")

--- a/drivers/linux/drv_kernelmod_zynq/CMakeLists.txt
+++ b/drivers/linux/drv_kernelmod_zynq/CMakeLists.txt
@@ -158,7 +158,7 @@ SET(MODULE_SOURCE_FILES
     ${KERNEL_SOURCE_DIR}/timesync/timesynckcal-linuxdpshm.c
     ${KERNEL_SOURCE_DIR}/veth/veth-linuxdpshm.c
     ${ARCH_SOURCE_DIR}/target-linuxkernel.c
-    ${STACK_SOURCE_DIR}/arch/linux/lock-dualproczynq.c
+    ${STACK_SOURCE_DIR}/arch/linux/lock-linuxdualproc.c
     )
 
 IF(CMAKE_SYSTEM_PROCESSOR MATCHES "^(i.86|x86(_64)?)$")

--- a/stack/cmake/stackfiles.cmake
+++ b/stack/cmake/stackfiles.cmake
@@ -627,12 +627,13 @@ SET(TARGET_WINDOWS_DUAL_SOURCES
     ${ARCH_SOURCE_DIR}/windows/lock-dualprocnoos.c
     )
 
-IF (CFG_COMPILE_LIB_MNAPP_ZYNQINTF OR CFG_COMPILE_LIB_CNAPP_ZYNQINTF)
+IF (CFG_COMPILE_LIB_MNAPP_ZYNQINTF OR CFG_COMPILE_LIB_CNAPP_ZYNQINTF OR
+    CFG_COMPILE_LIB_MNAPP_PCIEINTF)
     SET(TARGET_LINUX_SOURCES
         ${ARCH_SOURCE_DIR}/linux/target-linux.c
         ${ARCH_SOURCE_DIR}/linux/target-mutex.c
         ${ARCH_SOURCE_DIR}/linux/netif-linux.c
-        ${ARCH_SOURCE_DIR}/linux/lock-dualproczynq.c
+        ${ARCH_SOURCE_DIR}/linux/lock-linuxdualproc.c
         )
 ELSE ()
     SET(TARGET_LINUX_SOURCES

--- a/stack/src/arch/linux/lock-linuxdualproc.c
+++ b/stack/src/arch/linux/lock-linuxdualproc.c
@@ -1,8 +1,8 @@
 /**
 ********************************************************************************
-\file  linux/lock-dualproczynq.c
+\file  linux/lock-linuxdualproc.c
 
-\brief  Locks for Zynq with Linux in dual processor system which pcp runs on MicroBlaze
+\brief  Locks for Zynq & PCIe with Linux in dual processor system
 
 This target depending module provides lock functionality in dual processor
 system with shared memory.
@@ -110,7 +110,9 @@ This function initializes the lock instance.
 int target_initLock(OPLK_LOCK_T* pLock_p)
 {
     if (pLock_p == NULL)
+    {
         return -1;
+    }
 
     pLock_l = pLock_p;
 
@@ -134,7 +136,9 @@ int target_lock(void)
     UINT8  val;
 
     if (pLock_l == NULL)
+    {
         return -1;
+    }
 
     // spin if id is not written to shared memory
     do
@@ -165,7 +169,9 @@ This function frees the given lock.
 int target_unlock(void)
 {
     if (pLock_l == NULL)
+    {
         return -1;
+    }
 
     OPLK_IO_WR8(pLock_l, LOCK_UNLOCKED_C);
 


### PR DESCRIPTION
 - Rename lock-dualproczynq.c to lock-linuxdualproc.c as it is
   common for Linux dual processor designs
 - Modify the file name in CMakeList.txt of Zynq driver
 - Include the file name in CMakeList.txt of PCIe driver
   and stackfiles.cmake

**Note:** Resolved vera++ (T019 control structure) warnings in lock-linuxdualproc.c

This fix resolves #383.
