### PR TITLE
[FIX] Fix Zynq Hybrid performance issue

### DIFF
--- a/stack/include/oplk/targetdefs/linux.h
+++ b/stack/include/oplk/targetdefs/linux.h
@@ -106,11 +106,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define ATOMIC_MEM_OFFSET           0x80000 // $$ Get the atomic memory base address from config header
 #define OPLK_ATOMIC_INIT(base)
 #elif defined (__LINUX_ZYNQ__)
-// Check if Microblaze is being locked by any other processes
-// If so it returns an error stating that the resources cannot be created
-#define OPLK_ATOMIC_INIT(base) \
-    if (target_initLock(&base->lock) != 0) \
-        return kErrorNoResource
 #define ATOMIC_MEM_OFFSET           0
 #endif
 


### PR DESCRIPTION
 - Resolve the performance issue by removing macro definition for
   OPLK_ATOMIC_INIT in linux.h file as it is a repetition
   (already available in microblaze specific header files)

Both short and long run tests for 3 performance test has been tested and the results are on par with V2.7.0 results. 