### PR TITLE
[FIX] Fixed 2 bugs in the i210 driver

### DIFF
--- a/stack/src/kernel/edrv/edrv-i210.c
+++ b/stack/src/kernel/edrv/edrv-i210.c
@@ -1163,7 +1163,7 @@ tOplkError edrv_startTimer(const tTimerHdl* pTimerHdl_p, UINT32 index_p, UINT64 
 
     reg = 0;
     reg = EDRV_REGDW_READ(EDRV_TSIM);
-    reg |= (EDRV_TSIM_TT(index_p) | EDRV_TSICR_SYSTIM);
+    reg |= (EDRV_TSIM_TT(index_p));
     EDRV_REGDW_WRITE(EDRV_TSIM, reg);
 
     return kErrorOk;
@@ -1338,11 +1338,6 @@ static irqreturn_t edrvTimerInterrupt(int irqNum_p, void* ppDevInstData_p)
     status &= ~EDRV_INTR_ICR_TIME_SYNC;
     EDRV_REGDW_WRITE(EDRV_INTR_SET_REG, status);
     reg = EDRV_REGDW_READ(EDRV_TSICR);
-
-    if (reg & EDRV_TSICR_SYSTIM)
-    {
-        return handled;
-    }
 
     if (reg & EDRV_TSICR_TT0)
     {


### PR DESCRIPTION
Fixed 2 bugs in the i210 driver causing all powerlink communication to stop.

Bug1:
The timer interrupt has 3 possible causes in the Powerlink driver (See i210 datasheet, chapter 8.16.1):
*	SYSTIM Warp around, this will happen every second.
*	Target Time 0 Trigger, during cyclic communication used to start the new cycle.
*	Target Time 1 Trigger, during cyclic communication used to start the new cycle.
When ‘SYSTIM Warp around’ would occur at the same time as ‘Target Time 0/1 Trigger’, only ‘SYSTIM Warp around’ would be handled. The function would return, without handling the start of cycle. Without handling the start of cycle, all powerlink communication would stop.
This is fixed by ignoring the SYSTIM Warp around flag. Note that only disabling the SYSTIM interrupt would not fix the issue, because the flag would still be set.

Bug2:
Another error found was caused by 2 interrupt handlers reading and clearing the same registers.
This register is called EDRV_INTR_READ_REG in the driver, and IRC in the datasheet (See i210 datasheet, chapter 8.8.9). A read is performed on this register in the function: edrvTimerInterrupt and the function: edrvIrqHandler. Since this register is ‘Clear on read’, both interrupt functions being called at the same time causes problems.
To solve this error, the ‘SYSTIM Warp around’ interrupt is disabled in the function: edrv_startTimer. Since this interrupt is unused, it can be safely disabled.
The timer interrupt giving the start of cycle, and RX/TX interrupts should never happen at the same time in a Powerlink network. This interrupts don't need to be fixed.